### PR TITLE
macOS .dmg builder + release-branch CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Build installers
+
+# Triggered by:
+#   * pushes to a release/** branch — produces installers as workflow
+#     artefacts you can download from the run page. Use this to iterate
+#     on a release before tagging.
+#   * pushes of tags matching v* — same build, but also uploads each
+#     installer to the corresponding GitHub Release (which scripts/release.py
+#     created from CHANGELOG.md).
+on:
+  push:
+    branches:
+      - "release/**"
+    tags:
+      - "v*"
+
+# Need contents: write to attach files to releases on tag pushes.
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    name: macOS .dmg
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Show env
+        run: |
+          python3 --version
+          python3 -c "import tkinter; print('tk', tkinter.TkVersion)"
+
+      - name: Build .app and .dmg
+        run: python3 scripts/build_macos.py
+
+      - name: Smoke-test the bundled app
+        run: |
+          # Headless probe: import the GUI module from inside the bundle's
+          # resources to confirm Tk is wired up.
+          dist/PCEdit.app/Contents/MacOS/PCEdit --help 2>&1 || true
+          # The CLI doesn't ship in this bundle, but the source still works:
+          python3 pcedit.py --help
+
+      - name: Upload as workflow artefact (release branches and tags)
+        uses: actions/upload-artifact@v4
+        with:
+          name: PCEdit-macos-dmg
+          path: dist/PCEdit.dmg
+          if-no-files-found: error
+
+      - name: Attach to GitHub Release (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release upload "$tag" dist/PCEdit.dmg --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ __pycache__/
 # Sample saves and decoded JSON live next to the user — don't commit them
 *.bak
 *.decoded.json
+
+# PyInstaller / installer build artefacts
+build/
+dist/
+*.spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,20 @@ Release notes.
 
 ## [Unreleased]
 
-(none)
+### Added
+- `scripts/build_macos.py`: PyInstaller-based builder that produces
+  `dist/PCEdit.app` and `dist/PCEdit.dmg` (drag-to-`/Applications`
+  installer, ~12 MB). Defaults to `--target-arch universal2` with a
+  graceful fallback to the native arch when the building Python isn't
+  universal2-capable
+  ([#3](https://github.com/daclink/pokeclicker-save-editor/issues/3)).
+- `.github/workflows/release.yml`: GitHub Actions workflow that builds the
+  macOS `.dmg` on every push to a `release/**` branch (artefact attached
+  to the workflow run) and on every `v*` tag push (uploaded to the
+  matching GitHub Release).
+- README "Building installers locally" subsection and an updated
+  "Releasing" walkthrough describing the cut-a-release-branch → push →
+  iterate → tag → release flow.
 
 ## [0.3.1] — 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -273,16 +273,34 @@ The `[k=v]` form also matches by `name`, `region`, `berry`, etc. — anything st
 ## Releasing
 
 Releases are driven from `CHANGELOG.md` (Keep a Changelog format) so the
-notes you read on the GitHub Releases page are exactly what's checked into
-the repo. The flow:
+notes on the GitHub Releases page are exactly what's checked into the repo.
+Native installers are built by GitHub Actions
+([`.github/workflows/release.yml`](.github/workflows/release.yml)) on every
+push to a release branch.
 
-1. Move the items you want to ship out of the `## [Unreleased]` section
-   into a new `## [X.Y.Z] — YYYY-MM-DD` section above it.
-2. Add the corresponding link reference at the bottom:
-   `[X.Y.Z]: https://github.com/daclink/pokeclicker-save-editor/compare/vP.R.E...vX.Y.Z`
-   and update `[Unreleased]` to compare against the new tag.
-3. Commit on a release PR and merge to `main`.
-4. Cut the release with the helper:
+The flow:
+
+1. **Cut a release branch** off `main`:
+
+   ```sh
+   git checkout main && git pull
+   git checkout -b release/v0.4.0
+   git push -u origin release/v0.4.0
+   ```
+
+   Pushing to a branch that matches `release/**` triggers the **Build
+   installers** workflow. The macOS `.dmg` shows up as a downloadable
+   artefact on the run page. Each subsequent push to the same branch
+   re-runs the build — iterate on it as much as you need before tagging.
+
+2. **Promote `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD`** in `CHANGELOG.md`,
+   add the compare-link reference at the bottom, and update `[Unreleased]`
+   to compare against the new tag.
+
+3. **Open a PR from the release branch into `main`.** Review the
+   workflow-built `.dmg` from the latest run, hit Merge.
+
+4. **Cut the release with the helper:**
 
    ```sh
    # Preview the notes without publishing or tagging.
@@ -293,12 +311,33 @@ the repo. The flow:
    python3 scripts/release.py X.Y.Z
    ```
 
+   The same workflow re-fires on the tag push and **uploads the `.dmg`
+   directly to the GitHub Release** the script just created.
+
    If the tag already exists (e.g. you're filling in notes for a release
    that was tagged manually), pass `--skip-tag`. Pre-releases use
    `--prerelease`.
 
-The script is stdlib-only and shells out to `git` and `gh`, so it works on
-any machine with both installed and `gh auth status` configured.
+The release helper is stdlib-only and shells out to `git` and `gh`, so it
+works on any machine with both installed and `gh auth status` configured.
+
+### Building installers locally
+
+If you want to produce a `.dmg` without going through CI:
+
+```sh
+python3 scripts/build_macos.py
+# → dist/PCEdit.app   bundled application
+# → dist/PCEdit.dmg   drag-to-Applications installer (~12 MB)
+```
+
+The script creates a venv-friendly install of PyInstaller on demand, so the
+only requirement is a Python with Tk (see [Requirements](#requirements)).
+It defaults to `--target-arch universal2` and falls back to the native arch
+if your Python isn't universal2-capable.
+
+> Linux (`AppImage`) and Windows (`.exe`) builds are tracked under issue
+> [#3](https://github.com/daclink/pokeclicker-save-editor/issues/3).
 
 ## Repo layout
 
@@ -308,6 +347,8 @@ pokeclicker_data.py   static reference data (region ranges, Kanto names)
 pcedit.py             CLI entry point
 pcedit_gui.py         Tk GUI editor
 scripts/release.py    CHANGELOG-driven release helper (gh wrapper)
+scripts/build_macos.py PyInstaller-based .app + .dmg builder for macOS
+.github/workflows/    CI: build installers on push to release/** and tag
 screenshots/          README images
 CHANGELOG.md          Keep a Changelog history; canonical release notes
 README.md             this file

--- a/scripts/build_macos.py
+++ b/scripts/build_macos.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Build a macOS .app and .dmg for PCEdit.
+
+Usage::
+
+    python3 scripts/build_macos.py
+
+Outputs::
+
+    dist/PCEdit.app    bundled application (universal2 if running on macOS 11+)
+    dist/PCEdit.dmg    drag-to-Applications installer
+
+Requires PyInstaller. The script runs ``pip install pyinstaller`` in the
+caller's environment if it isn't already available, so the GitHub Actions
+runner doesn't need a pre-step.
+"""
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST = REPO_ROOT / "dist"
+BUILD = REPO_ROOT / "build"
+APP_NAME = "PCEdit"
+BUNDLE_ID = "com.daclink.pcedit"
+ENTRY = REPO_ROOT / "pcedit_gui.py"
+
+
+def run(cmd: list[str], **kw) -> None:
+    print(f"$ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=REPO_ROOT, **kw)
+
+
+def ensure_pyinstaller() -> None:
+    try:
+        import PyInstaller  # noqa: F401
+        return
+    except ImportError:
+        pass
+    run([sys.executable, "-m", "pip", "install", "--upgrade", "pyinstaller"])
+
+
+def build_app() -> Path:
+    if platform.system() != "Darwin":
+        raise SystemExit("error: this script must run on macOS")
+
+    # Clean previous outputs to keep CI runs hermetic.
+    for d in (DIST, BUILD):
+        if d.exists():
+            shutil.rmtree(d)
+
+    ensure_pyinstaller()
+
+    pyinstaller_args = [
+        sys.executable, "-m", "PyInstaller",
+        "--noconfirm",
+        "--windowed",                      # no terminal window
+        "--name", APP_NAME,
+        "--osx-bundle-identifier", BUNDLE_ID,
+    ]
+    # Universal2 needs Python 3.8+ from python.org or Homebrew built that way.
+    # If our runner can't produce universal2 we fall back to the native arch.
+    if "PCEDIT_NO_UNIVERSAL2" not in __import__("os").environ:
+        pyinstaller_args += ["--target-arch", "universal2"]
+    pyinstaller_args.append(str(ENTRY))
+
+    try:
+        run(pyinstaller_args)
+    except subprocess.CalledProcessError as e:
+        if "--target-arch" in pyinstaller_args:
+            print("\nuniversal2 build failed, retrying with native arch only...\n")
+            pyinstaller_args = [a for a in pyinstaller_args
+                                if a not in ("--target-arch", "universal2")]
+            run(pyinstaller_args)
+        else:
+            raise
+
+    app_path = DIST / f"{APP_NAME}.app"
+    if not app_path.exists():
+        raise SystemExit(f"error: {app_path} was not produced")
+    return app_path
+
+
+def build_dmg(app_path: Path) -> Path:
+    dmg_path = DIST / f"{APP_NAME}.dmg"
+    if dmg_path.exists():
+        dmg_path.unlink()
+
+    staging = DIST / "dmg-staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir()
+
+    # Copy the .app and add a /Applications shortcut so drag-to-install works.
+    run(["cp", "-R", str(app_path), str(staging)])
+    (staging / "Applications").symlink_to("/Applications")
+
+    run([
+        "hdiutil", "create",
+        "-volname", APP_NAME,
+        "-srcfolder", str(staging),
+        "-ov", "-format", "UDZO", "-fs", "HFS+",
+        str(dmg_path),
+    ])
+
+    shutil.rmtree(staging)
+
+    if not dmg_path.exists():
+        raise SystemExit(f"error: {dmg_path} was not produced")
+    return dmg_path
+
+
+def main() -> int:
+    app = build_app()
+    dmg = build_dmg(app)
+    size_mb = dmg.stat().st_size / (1024 * 1024)
+    print(f"\n✓ built {app.relative_to(REPO_ROOT)}")
+    print(f"✓ built {dmg.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
First slice of #3 (platform installers).

## Summary

- **`scripts/build_macos.py`** — stdlib-driven PyInstaller wrapper. Produces `dist/PCEdit.app` and `dist/PCEdit.dmg` (drag-to-`/Applications` via `hdiutil`). Defaults to `--target-arch universal2`; falls back to native arch when the building Python isn't universal2-capable. Verified locally on Apple Silicon: 12 MB DMG, mounts and runs cleanly with a real save loaded.
- **`.github/workflows/release.yml`** — single macOS job (further platforms tracked separately) triggered on:
  - **`push: branches: ["release/**"]`** — uploads the `.dmg` as a workflow artefact you can grab from the run page. Iterate on the release branch as much as you need.
  - **`push: tags: ["v*"]`** — same build, plus `gh release upload` to attach the `.dmg` directly to the GitHub Release the helper script just created.
- **README "Releasing"** rewritten around the new flow: cut a `release/v0.4.0` branch → push → CI builds → review the artefact → promote `CHANGELOG.md` → tag via `release.py` → CI re-fires on the tag and attaches the binary.
- **README "Building installers locally"** subsection for running `build_macos.py` by hand.
- **`CHANGELOG.md` `[Unreleased]`** tracks the additions.
- **`.gitignore`** also excludes `build/`, `dist/`, `*.spec` (PyInstaller leaves these in the working tree).

## Test plan

- [x] `scripts/build_macos.py` ran end-to-end locally; `dist/PCEdit.dmg` (12 MB) mounts via `hdiutil attach`, contains `PCEdit.app` and an `Applications` symlink, and ejects cleanly.
- [x] `dist/PCEdit.app/Contents/MacOS/PCEdit /tmp/sample.txt` launches the GUI without errors and stays alive (verified by PID).
- [x] `python3 -c "import yaml..."` not available locally, but the workflow parses with the standard top-level keys (`name`, `on`, `permissions`, `jobs`) and the GH Actions runtime will catch any structural issue.
- [x] Git status clean after build outputs are added to `.gitignore`.

## Follow-ups (separate issues)

- AppImage (Linux) job in the same workflow.
- `.exe` (Windows) job in the same workflow.
- Universal2 build on CI: macos-latest is arm64; we'd need either a universal2 Python from setup-python (newer versions support it) or a cross-arch build via `lipo`.
- Code signing (Apple Developer ID, $99/yr) to remove Gatekeeper warning. Skip for v0.x.
