### PR TITLE
Release v0.4.0: app icon + Windows/Linux installers + 3-platform CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release notes.
 
 ## [Unreleased]
 
+(none)
+
+## [0.4.0] — 2026-05-01
+
 ### Added
 - **App icon.** Pokéball SVG sourced from
   [pokeclicker.com](https://www.pokeclicker.com/) rendered into platform
@@ -119,7 +123,8 @@ Release notes.
   - **Caught Pokémon**: editable table with double-click dialog.
 - Round-trip verified byte-exact on the v0.10.25 sample save.
 
-[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Release notes.
 - README "Building installers locally" rewritten for all three platforms;
   new "Regenerating the app icon" subsection. Repo layout entry updated
   with the new files.
+- README "Download & install" section near the top of the file with a
+  per-platform download/install table and a link to the latest release
+  page, so first-time users land on a binary without scrolling.
+
+### Fixed
+- Build scripts crashed on Windows when printing the success summary
+  (cp1252 codec couldn't encode the `✓` glyph). Switched all build
+  scripts to ASCII output and added `sys.stdout.reconfigure(encoding=
+  "utf-8", errors="replace")` as defence-in-depth. The Windows CI build
+  now succeeds end-to-end.
 
 ## [0.3.1] — 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ USE AT YOUR OWN RISK. UNOFFICIAL, educational use only.
 
 A small Python CLI for inspecting and editing [PokeClicker](https://www.pokeclicker.com/) save exports. Tested against `v0.10.25`.
 
+> **Latest release:** see <https://github.com/daclink/pokeclicker-save-editor/releases/latest>.
+> Pre-built installers are attached for macOS, Windows, and Linux — see *Download & install* below.
+
+## Download & install
+
+| platform | file | install |
+|---|---|---|
+| **macOS** (Apple Silicon, Intel via Rosetta) | `PCEdit-macos.dmg` | Double-click → drag **PCEdit** to **Applications**. First launch: right-click → **Open** to bypass the *unidentified developer* prompt (the app isn't code-signed yet). |
+| **Windows 10 / 11** | `PCEdit-windows.exe` | Save anywhere and double-click to run. SmartScreen may show a warning on the first launch — click **More info → Run anyway** (the binary isn't code-signed yet). |
+| **Linux x86_64** (glibc-based distros) | `PCEdit-linux-x86_64.tar.gz` | `tar xzf PCEdit-linux-x86_64.tar.gz && chmod +x PCEdit-linux-x86_64 && ./PCEdit-linux-x86_64`. The tarball also contains a 256 px icon, a `.desktop` file, and a short README for optional desktop integration. |
+
+All three downloads are at the **Assets** section of every release on the [Releases page](https://github.com/daclink/pokeclicker-save-editor/releases).
+
+If you want the source instead of a binary, see [Build](#build).
+
 ## Save format
 
 A PokeClicker `.txt` save export is **base64 of a JSON document**.

--- a/scripts/build_linux.py
+++ b/scripts/build_linux.py
@@ -125,10 +125,15 @@ def main() -> int:
         tf.add(readme_path, arcname="README.txt")
 
     size_mb = tar_path.stat().st_size / (1024 * 1024)
-    print(f"\n✓ built {bin_path.relative_to(REPO_ROOT)}")
-    print(f"✓ built {tar_path.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
+    print(f"\nOK built {bin_path.relative_to(REPO_ROOT)}")
+    print(f"OK built {tar_path.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
     return 0
 
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/build_macos.py
+++ b/scripts/build_macos.py
@@ -127,10 +127,15 @@ def main() -> int:
         final.unlink()
     dmg.rename(final)
     size_mb = final.stat().st_size / (1024 * 1024)
-    print(f"\n✓ built {app.relative_to(REPO_ROOT)}")
-    print(f"✓ built {final.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
+    print(f"\nOK built {app.relative_to(REPO_ROOT)}")
+    print(f"OK built {final.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
     return 0
 
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/build_windows.py
+++ b/scripts/build_windows.py
@@ -72,9 +72,14 @@ def main() -> int:
     src.rename(final)
 
     size_mb = final.stat().st_size / (1024 * 1024)
-    print(f"\n✓ built {final.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
+    print(f"\nOK built {final.relative_to(REPO_ROOT)}  ({size_mb:.1f} MB)")
     return 0
 
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/make_icons.py
+++ b/scripts/make_icons.py
@@ -73,7 +73,7 @@ def make_icns() -> None:
     out = ICON_DIR / "PCEdit.icns"
     run(["iconutil", "-c", "icns", str(iconset), "-o", str(out)])
     shutil.rmtree(iconset)
-    print(f"✓ {out.relative_to(REPO_ROOT)}")
+    print(f"OK {out.relative_to(REPO_ROOT)}")
 
 
 def make_ico() -> None:
@@ -84,14 +84,14 @@ def make_ico() -> None:
         "-define", f"icon:auto-resize={sizes}",
         str(out),
     ])
-    print(f"✓ {out.relative_to(REPO_ROOT)}")
+    print(f"OK {out.relative_to(REPO_ROOT)}")
 
 
 def make_pngs() -> None:
     for sz in (256, 512):
         out = ICON_DIR / f"PCEdit-{sz}.png"
         png(sz, out)
-        print(f"✓ {out.relative_to(REPO_ROOT)}")
+        print(f"OK {out.relative_to(REPO_ROOT)}")
 
 
 def main() -> int:
@@ -103,6 +103,11 @@ def main() -> int:
     make_icns()
     return 0
 
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -136,9 +136,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.prerelease:
         cmd.append("--prerelease")
     run(cmd, input_text=notes)
-    print(f"\n✓ released {tag}")
+    print(f"\nOK released {tag}")
     return 0
 
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Promotes the v0.4.0 work merged via #21 (icon + builders + CI) and ships the README *Download & install* section with binary install instructions.

CI on this branch is green across macOS, Windows, and Linux. After merge, `python3 scripts/release.py 0.4.0` will tag and create the GitHub Release; the workflow re-fires on the tag and uploads `PCEdit-macos.dmg`, `PCEdit-windows.exe`, and `PCEdit-linux-x86_64.tar.gz` directly to the release.

Closes #3.
