### PR TITLE
Suppress Spotlight + retry hdiutil for macOS DMG build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ Release notes.
 
 ## [Unreleased]
 
-(none)
+### Fixed
+- macOS `.dmg` build flake on GitHub Actions
+  ([#23](https://github.com/daclink/pokeclicker-save-editor/issues/23)).
+  After PyInstaller's BUNDLE/codesign step the runner occasionally held a
+  transient lock on the staging directory, making `hdiutil create` fail
+  with `Resource busy`. `scripts/build_macos.py` now suppresses Spotlight
+  on the staging directory (touches `.metadata_never_index`) and wraps
+  `hdiutil create` in a 3-attempt retry loop with linear backoff (2 s,
+  4 s, 6 s).
 
 ## [0.4.0] — 2026-05-01
 

--- a/scripts/build_macos.py
+++ b/scripts/build_macos.py
@@ -89,6 +89,7 @@ def build_app() -> Path:
 
 
 def build_dmg(app_path: Path) -> Path:
+    import time
     dmg_path = DIST / f"{APP_NAME}.dmg"
     if dmg_path.exists():
         dmg_path.unlink()
@@ -102,13 +103,36 @@ def build_dmg(app_path: Path) -> Path:
     run(["cp", "-R", str(app_path), str(staging)])
     (staging / "Applications").symlink_to("/Applications")
 
-    run([
+    # Tell Spotlight to skip the staging directory. macOS-latest CI runners
+    # otherwise grab a transient lock right after PyInstaller's codesign step
+    # finishes, which makes `hdiutil create` fail with "Resource busy".
+    # Documented Apple behaviour: presence of .metadata_never_index excludes
+    # the directory from indexing.
+    (staging / ".metadata_never_index").touch()
+
+    # Belt-and-suspenders: short retry loop. PyInstaller's BUNDLE step signs
+    # the .app and the codesign daemon can hold a handle for a beat. Three
+    # attempts with linear backoff is more than enough in practice.
+    hdiutil_cmd = [
         "hdiutil", "create",
         "-volname", APP_NAME,
         "-srcfolder", str(staging),
         "-ov", "-format", "UDZO", "-fs", "HFS+",
         str(dmg_path),
-    ])
+    ]
+    last_err: Exception | None = None
+    for attempt in range(3):
+        try:
+            run(hdiutil_cmd)
+            last_err = None
+            break
+        except subprocess.CalledProcessError as e:
+            last_err = e
+            wait = 2 + attempt * 2  # 2s, 4s, 6s
+            print(f"hdiutil attempt {attempt + 1} failed; retrying in {wait}s...")
+            time.sleep(wait)
+    if last_err is not None:
+        raise last_err
 
     shutil.rmtree(staging)
 


### PR DESCRIPTION
Closes #23. Two-pronged fix for the v0.4.0 macOS build flake: touch `.metadata_never_index` in the staging dir so Spotlight skips it, and wrap `hdiutil create` in a 3-attempt retry with linear backoff. Local rebuild produces the same 13.2 MB DMG; will exercise on CI when v0.4.1 is tagged.