### PR TITLE
Release v0.4.1: macOS hdiutil retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release notes.
 
 ## [Unreleased]
 
+(none)
+
+## [0.4.1] — 2026-05-01
+
 ### Fixed
 - macOS `.dmg` build flake on GitHub Actions
   ([#23](https://github.com/daclink/pokeclicker-save-editor/issues/23)).
@@ -131,7 +135,8 @@ Release notes.
   - **Caught Pokémon**: editable table with double-click dialog.
 - Round-trip verified byte-exact on the v0.10.25 sample save.
 
-[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.2.1...v0.3.0


### PR DESCRIPTION
Promotes the hdiutil retry/spotlight-suppress fix from #23 into [0.4.1]. After merge, `scripts/release.py 0.4.1` tags and the CI matrix re-fires to upload all three artefacts (and exercises the new retry path on real CI hardware).