### PR TITLE
Release v0.5.0: update check on launch + Pokédex stat back-fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release notes.
 
 ## [Unreleased]
 
+(none)
+
+## [0.5.0] — 2026-05-01
+
 ### Added
 - **Update check on launch**
   ([#19](https://github.com/daclink/pokeclicker-save-editor/issues/19)).
@@ -166,7 +170,8 @@ Release notes.
   - **Caught Pokémon**: editable table with double-click dialog.
 - Round-trip verified byte-exact on the v0.10.25 sample save.
 
-[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
Promotes [Unreleased] containing #19 and #5 (merged via #27) to [0.5.0]. _version.py is already at 0.5.0 so the release-script self-check passes. After merge, scripts/release.py 0.5.0 cuts the GitHub Release and CI uploads all three platform binaries.