### PR TITLE
Release v0.5.1: vitamin + Master Ball multiplier resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release notes.
 
 ## [Unreleased]
 
+(none)
+
+## [0.5.1] — 2026-05-01
+
 ### Added
 - **Calcium and Carbos vitamin resets**
   ([#17](https://github.com/daclink/pokeclicker-save-editor/issues/17)).
@@ -186,7 +190,8 @@ Release notes.
   - **Caught Pokémon**: editable table with double-click dialog.
 - Round-trip verified byte-exact on the v0.10.25 sample save.
 
-[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.3.1...v0.4.0


### PR DESCRIPTION
Promotes [Unreleased] (#17, #18, key-pruning hygiene) to [0.5.1]. _version.py already bumped on the feature PR. After merge: scripts/release.py 0.5.1 cuts the GitHub Release, CI uploads all three platform binaries.