### PR TITLE
v0.6.0: Help menu + manual update check + bak/ folder layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,35 @@ Release notes.
 
 ## [Unreleased]
 
-(none)
+### Added
+- **Settings + Help menubar.** New top-level **Settings** menu (Update
+  check on launch, Backup layout submenu) and **Help** menu (Check for
+  updates…, Browse all backups…, About PCEdit). Settings persist to
+  `<user-config>/pcedit/settings.json`.
+- **Manual update check** ([#20](https://github.com/daclink/pokeclicker-save-editor/issues/20)).
+  *Help → Check for updates…* opens a modal that always hits the network
+  (bypasses the 24 h cache from #19) and shows one of three states:
+  *latest* / *available* (with *Open release notes*) / *error*.
+- **Backup layout setting** ([#16](https://github.com/daclink/pokeclicker-save-editor/issues/16)).
+  New `backup_layout` setting picks between two layouts:
+  - `"folder"` (new default): backups land in a sibling `bak/` folder
+    with timestamped filenames (`<stem>.YYYYMMDD-HHMMSS<suffix>.bak`)
+    so multiple edits accumulate history.
+  - `"sidecar"` (legacy): single `<file>.bak` next to the save,
+    overwritten on each save. Mirrors pre-v0.6.0 behaviour.
+  Toggle from **Settings → Backup layout**.
+- **Browse all backups dialog.** *Help → Browse all backups…* lists every
+  backup of the loaded save (newest first, with timestamp and folder
+  tag), with *Restore selected* and *Reveal in folder* actions.
+- New `pcedit_backup.py` module shared by the GUI and the CLI; exports
+  `make_backup`, `latest_backup`, `list_backups`. The CLI's
+  `pcedit undo` now finds the most recent backup across either layout.
+
+### Changed
+- *Undo (.bak)* in the GUI and `pcedit undo` in the CLI no longer assume
+  a specific backup location — they walk both the sidecar position and
+  the `bak/` folder and pick the newest by mtime, so undo works after
+  toggling layouts mid-session.
 
 ## [0.5.1] — 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ re-loads — handy if a save you just wrote causes the game to misbehave.
 The status bar at the bottom of the window shows what just happened
 (`loaded …`, `saved …`, `restored …`, etc.).
 
+#### Menubar
+
+| menu | items |
+|---|---|
+| **Settings** | *Update check on launch* (toggle the silent on-launch GitHub release check). *Backup layout* submenu picks **Folder** (sibling `bak/` directory with timestamped files — the default since v0.6.0) or **Sidecar** (single `<file>.bak`, overwritten on each save — the legacy layout). |
+| **Help** | *Check for updates…* hits the GitHub Releases API immediately (bypasses the 24 h cache from the on-launch check) and shows a three-state result. *Browse all backups…* lists every backup of the loaded save with timestamps, plus *Restore selected* / *Reveal in folder*. *About PCEdit* shows the version and source link. |
+
 The status bar at the bottom shows what just happened.
 
 ### CLI
@@ -282,10 +289,26 @@ The `[k=v]` form also matches by `name`, `region`, `berry`, etc. — anything st
 
 ## Safety
 
-- `set` and the convenience commands write to the original file by default, **after copying it to `<file>.bak`**. Use `-o new_save.txt` to write to a new file instead.
-- Round-trip is byte-exact for unmodified saves — verified with the test cases this repo was developed against.
-- The tool does **not** validate game logic. You can hand the game a Pokédex entry it doesn't expect, and the game may crash or sanitize it on the next save. Edit small things first, save in-game, and confirm before going wild.
-- This is for tinkering with your own local save. Don't use it for cheating online leaderboards (PokeClicker is single-player but be a good neighbor).
+- Every write goes through a backup first. The default since v0.6.0 is a
+  sibling `bak/` folder with timestamped files
+  (`<save-stem>.YYYYMMDD-HHMMSS<suffix>.bak`) so multiple edits accumulate
+  history; **Undo** restores the most recent. Toggle to the legacy
+  single-file `<file>.bak` layout via **Settings → Backup layout** in the
+  GUI (the same setting is read by the CLI). Use the GUI's *Help → Browse
+  all backups…* dialog, or look in the `bak/` folder, to recover an older
+  edit.
+- `pcedit set`, `money`, `give`, etc. write to the original file by
+  default. Use `-o new_save.txt` to write somewhere else and skip the
+  in-place overwrite entirely.
+- Round-trip is byte-exact for unmodified saves — verified with the test
+  cases this repo was developed against.
+- The tool does **not** validate game logic. You can hand the game a
+  Pokédex entry it doesn't expect, and the game may crash or sanitize it
+  on the next save. Edit small things first, save in-game, and confirm
+  before going wild.
+- This is for tinkering with your own local save. Don't use it for
+  cheating online leaderboards (PokeClicker is single-player but be a
+  good neighbor).
 
 ## Releasing
 
@@ -382,6 +405,9 @@ rebuild the `.icns`. The source SVG is the Pokéball icon from
 ```
 pokeclicker_save.py   format library (decode, encode, path get/set)
 pokeclicker_data.py   static reference data (region ranges, Kanto names)
+pcedit_backup.py      backup helpers (folder/sidecar layouts)
+pcedit_updates.py     update-check fetcher + persisted-settings helpers
+_version.py           single source of truth for __version__
 pcedit.py             CLI entry point
 pcedit_gui.py         Tk GUI editor
 scripts/release.py    CHANGELOG-driven release helper (gh wrapper)

--- a/_version.py
+++ b/_version.py
@@ -4,4 +4,4 @@ Bumped automatically by ``scripts/release.py`` before tagging, so the
 constant always matches the latest tag on ``main``.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/pcedit.py
+++ b/pcedit.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """pcedit — PokeClicker save editor (CLI).
 
-Round-trips byte-exact for unmodified saves. Always writes a `.bak` next to
-the target before overwriting.
+Round-trips byte-exact for unmodified saves. Backups follow the
+`backup_layout` setting (folder by default, sidecar legacy) — see
+`pcedit_backup`.
 """
 from __future__ import annotations
 
@@ -22,6 +23,7 @@ from pokeclicker_save import (
     set_path,
     _coerce_scalar,
 )
+from pcedit_backup import latest_backup, list_backups, make_backup
 
 REGIONS = [
     "Kanto", "Johto", "Hoenn", "Sinnoh", "Unova",
@@ -50,7 +52,7 @@ def load(path: str) -> dict:
 def save(data: dict, path: str, *, was_encoded: bool, backup: bool = True) -> None:
     p = Path(path)
     if backup and p.exists():
-        shutil.copy2(p, p.with_suffix(p.suffix + ".bak"))
+        make_backup(p)
     if was_encoded:
         encode_file(data, p)
     else:
@@ -242,9 +244,11 @@ def cmd_caught(args: argparse.Namespace) -> int:
 
 def cmd_undo(args: argparse.Namespace) -> int:
     target = Path(args.input)
-    bak = target.with_suffix(target.suffix + ".bak")
-    if not bak.exists():
-        print(f"no backup found at {bak}")
+    bak = latest_backup(target)
+    if bak is None:
+        print(f"no backup found for {target}")
+        print(f"  looked for {target.suffix}.bak next to the file and any "
+              f"timestamped .bak files inside a sibling bak/ folder.")
         return 1
     shutil.copy2(bak, target)
     print(f"restored {target} from {bak}")

--- a/pcedit_backup.py
+++ b/pcedit_backup.py
@@ -1,0 +1,93 @@
+"""Save-file backup helpers, shared by the GUI and the CLI.
+
+Two layouts, picked via ``pcedit_updates.get_setting("backup_layout", ...)``:
+
+- ``"folder"`` (default since v0.6.0): a sibling ``bak/`` directory next to
+  the save, with timestamped filenames so multiple edits accumulate
+  history. ``Undo`` restores the most recent.
+- ``"sidecar"`` (legacy): a single ``<file>.bak`` next to the save, which
+  is overwritten on each save. Mirrors the pre-v0.6.0 behaviour.
+
+The helpers always check both locations on read, so undo still works after
+toggling layouts mid-run or against older saves.
+"""
+from __future__ import annotations
+
+import datetime
+import shutil
+from pathlib import Path
+
+from pcedit_updates import get_setting
+
+LAYOUT_FOLDER = "folder"
+LAYOUT_SIDECAR = "sidecar"
+DEFAULT_LAYOUT = LAYOUT_FOLDER
+
+BAK_DIR_NAME = "bak"
+TIMESTAMP_FMT = "%Y%m%d-%H%M%S"
+
+
+def current_layout() -> str:
+    layout = get_setting("backup_layout", DEFAULT_LAYOUT)
+    return layout if layout in (LAYOUT_FOLDER, LAYOUT_SIDECAR) else DEFAULT_LAYOUT
+
+
+# --- write paths -------------------------------------------------------------
+
+def _sidecar_path(save_path: Path) -> Path:
+    return save_path.with_suffix(save_path.suffix + ".bak")
+
+
+def _folder_path(save_path: Path, *, when: datetime.datetime | None = None) -> Path:
+    when = when or datetime.datetime.now()
+    bak_dir = save_path.parent / BAK_DIR_NAME
+    ts = when.strftime(TIMESTAMP_FMT)
+    return bak_dir / f"{save_path.stem}.{ts}{save_path.suffix}.bak"
+
+
+def make_backup(save_path: Path) -> Path:
+    """Copy ``save_path`` to a backup according to the active layout.
+
+    Caller is responsible for ensuring ``save_path`` exists. Returns the
+    path of the backup that was just written.
+    """
+    if current_layout() == LAYOUT_SIDECAR:
+        bak = _sidecar_path(save_path)
+        shutil.copy2(save_path, bak)
+        return bak
+    bak = _folder_path(save_path)
+    bak.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(save_path, bak)
+    return bak
+
+
+# --- read paths --------------------------------------------------------------
+
+def list_backups(save_path: Path) -> list[Path]:
+    """Return every backup for ``save_path``, newest first.
+
+    Includes both the sidecar and any timestamped files under ``bak/`` so
+    undo still works after toggling layouts. Sorted by mtime descending.
+    """
+    out: list[Path] = []
+    sidecar = _sidecar_path(save_path)
+    if sidecar.is_file():
+        out.append(sidecar)
+
+    bak_dir = save_path.parent / BAK_DIR_NAME
+    if bak_dir.is_dir():
+        prefix = save_path.stem + "."
+        for p in bak_dir.iterdir():
+            if (p.is_file()
+                    and p.name.startswith(prefix)
+                    and p.name.endswith(save_path.suffix + ".bak")):
+                out.append(p)
+
+    out.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return out
+
+
+def latest_backup(save_path: Path) -> Path | None:
+    """Return the most recent backup for ``save_path``, or ``None``."""
+    backups = list_backups(save_path)
+    return backups[0] if backups else None

--- a/pcedit_gui.py
+++ b/pcedit_gui.py
@@ -12,6 +12,7 @@ a `.bak` next to the target file before overwriting.
 """
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 import tkinter as tk
@@ -23,7 +24,16 @@ from typing import Any
 from _version import __version__
 from pokeclicker_save import decode_file, encode_file
 from pokeclicker_data import REGION_RANGES, name_for
+from pcedit_backup import (
+    LAYOUT_FOLDER,
+    LAYOUT_SIDECAR,
+    current_layout,
+    latest_backup,
+    list_backups,
+    make_backup,
+)
 from pcedit_updates import (
+    REPO,
     UpdateResult,
     check_for_update_async,
     get_setting,
@@ -93,6 +103,7 @@ class PCEditGUI(tk.Tk):
         self.path: Path | None = None
         self.data: dict | None = None
 
+        self._build_menubar()
         self._build_top_bar()
         self._build_update_banner()
         self._build_status_bar()
@@ -102,6 +113,61 @@ class PCEditGUI(tk.Tk):
         # Kick off the update check 200 ms after mainloop starts so first
         # paint is unaffected. Honours the "update_check_on_launch" setting.
         self.after(200, self._kickoff_update_check)
+
+    # --- menubar ----------------------------------------------------------
+
+    def _build_menubar(self) -> None:
+        menubar = tk.Menu(self)
+
+        # Settings menu
+        settings_menu = tk.Menu(menubar, tearoff=0)
+        # update_check_on_launch toggle
+        self._auto_check_var = tk.BooleanVar(
+            value=bool(get_setting("update_check_on_launch", True)))
+
+        def _persist_auto_check() -> None:
+            set_setting("update_check_on_launch", self._auto_check_var.get())
+
+        settings_menu.add_checkbutton(
+            label="Update check on launch",
+            variable=self._auto_check_var,
+            command=_persist_auto_check)
+
+        # backup_layout submenu (radio)
+        layout_menu = tk.Menu(settings_menu, tearoff=0)
+        self._backup_layout_var = tk.StringVar(value=current_layout())
+
+        def _persist_layout() -> None:
+            set_setting("backup_layout", self._backup_layout_var.get())
+            self.status_var.set(
+                f"backup layout: {self._backup_layout_var.get()}")
+
+        layout_menu.add_radiobutton(
+            label="Folder (bak/ with timestamps)",
+            value=LAYOUT_FOLDER,
+            variable=self._backup_layout_var,
+            command=_persist_layout)
+        layout_menu.add_radiobutton(
+            label="Sidecar (<file>.bak, overwritten)",
+            value=LAYOUT_SIDECAR,
+            variable=self._backup_layout_var,
+            command=_persist_layout)
+        settings_menu.add_cascade(label="Backup layout", menu=layout_menu)
+
+        menubar.add_cascade(label="Settings", menu=settings_menu)
+
+        # Help menu
+        help_menu = tk.Menu(menubar, tearoff=0)
+        help_menu.add_command(label="Check for updates…",
+                              command=self._open_update_check_dialog)
+        help_menu.add_command(label="Browse all backups…",
+                              command=self._open_backups_dialog)
+        help_menu.add_separator()
+        help_menu.add_command(label="About PCEdit",
+                              command=self._open_about_dialog)
+        menubar.add_cascade(label="Help", menu=help_menu)
+
+        self.config(menu=menubar)
 
     # --- top + status -----------------------------------------------------
 
@@ -194,28 +260,44 @@ class PCEditGUI(tk.Tk):
         except ValueError as e:
             messagebox.showerror("Invalid value", str(e))
             return
-        bak = self.path.with_suffix(self.path.suffix + ".bak")
         try:
-            shutil.copy2(self.path, bak)
+            bak = make_backup(self.path)
             encode_file(self.data, self.path)
         except OSError as e:
             messagebox.showerror("Save failed", str(e))
             return
-        self.status_var.set(f"saved {self.path.name}  (backup: {bak.name})")
+        # Show a friendly "next to file" or "in bak/" hint instead of
+        # the absolute backup path.
+        if bak.parent == self.path.parent:
+            where = bak.name
+        else:
+            where = f"bak/{bak.name}"
+        self.status_var.set(f"saved {self.path.name}  (backup: {where})")
 
     def on_undo(self) -> None:
         if self.path is None:
             return
-        bak = self.path.with_suffix(self.path.suffix + ".bak")
-        if not bak.exists():
-            messagebox.showinfo("No backup", f"No backup found at\n{bak}")
+        bak = latest_backup(self.path)
+        if bak is None:
+            messagebox.showinfo(
+                "No backup",
+                f"No backup found for\n{self.path.name}\n\n"
+                f"Looked for {self.path.suffix}.bak next to the file and any "
+                f"{self.path.stem}.YYYYMMDD-HHMMSS{self.path.suffix}.bak inside "
+                f"a sibling bak/ folder.")
             return
-        if not messagebox.askyesno("Undo from backup",
-                                    f"Restore {self.path.name} from {bak.name}?"):
+        # Show the backup's timestamp/name so the user knows what they're rolling back to.
+        if bak.parent == self.path.parent:
+            origin = bak.name
+        else:
+            origin = f"bak/{bak.name}"
+        if not messagebox.askyesno(
+                "Undo from backup",
+                f"Restore {self.path.name} from {origin}?"):
             return
         shutil.copy2(bak, self.path)
         self.load(self.path)
-        self.status_var.set(f"restored {self.path.name} from {bak.name}")
+        self.status_var.set(f"restored {self.path.name} from {origin}")
 
     def load(self, path: Path) -> None:
         try:
@@ -271,6 +353,24 @@ class PCEditGUI(tk.Tk):
                 webbrowser.open(self._update_url)
             except Exception:  # noqa: BLE001
                 pass
+
+    def _open_update_check_dialog(self) -> None:
+        UpdateCheckDialog(self)
+
+    def _open_backups_dialog(self) -> None:
+        if self.path is None:
+            messagebox.showinfo("Backups", "Open a save first.")
+            return
+        BackupsDialog(self, self.path)
+
+    def _open_about_dialog(self) -> None:
+        repo_url = f"https://github.com/{REPO}"
+        msg = (f"PCEdit — PokeClicker save editor\n"
+               f"Version {__version__}\n\n"
+               f"Source / releases:\n{repo_url}\n\n"
+               f"Tested against PokeClicker v0.10.25.\n"
+               f"Unofficial. CC0 1.0 licensed.")
+        messagebox.showinfo("About PCEdit", msg)
 
     def _dismiss_update(self) -> None:
         # Persist so this exact release stays dismissed across launches.
@@ -1117,6 +1217,160 @@ def _caught_on_edit(self, _evt=None):  # type: ignore[no-redef]
 
 
 CaughtTab._on_edit = _caught_on_edit  # type: ignore[assignment]
+
+
+# --- top-level dialogs ------------------------------------------------------
+
+class UpdateCheckDialog(tk.Toplevel):
+    """Manual update check (Help → Check for updates…).
+
+    Bypasses the 24 h cache from the on-launch check and always hits the
+    network. Shows three states: latest / available / error.
+    """
+
+    def __init__(self, parent: PCEditGUI) -> None:
+        super().__init__(parent)
+        self.title("Check for updates")
+        self.transient(parent)
+        self.resizable(False, False)
+        self.grab_set()
+        self._parent = parent
+        self._url: str | None = None
+
+        body = ttk.Frame(self, padding=14)
+        body.pack(fill="both", expand=True)
+        self.status = ttk.Label(body, text="Checking github.com…",
+                                wraplength=360, justify="left")
+        self.status.pack(anchor="w")
+
+        self.button_row = ttk.Frame(body)
+        self.button_row.pack(fill="x", pady=(12, 0))
+        self._open_btn = ttk.Button(self.button_row, text="Open release notes",
+                                    command=self._open_url, state="disabled")
+        self._open_btn.pack(side="left")
+        ttk.Button(self.button_row, text="Close",
+                   command=self.destroy).pack(side="right")
+
+        self.bind("<Escape>", lambda _e: self.destroy())
+
+        # Force a fresh fetch (no cache) and bounce the result to the Tk
+        # main thread.
+        def on_result(result: UpdateResult) -> None:
+            self.after(0, lambda: self._render(result))
+        check_for_update_async(on_result, force=True)
+
+    def _render(self, result: UpdateResult) -> None:
+        if result.status == "current":
+            self.status.configure(
+                text=f"You're on the latest version (v{result.current}).")
+        elif result.status == "available":
+            self._url = result.html_url
+            self._open_btn.configure(state="normal")
+            self.status.configure(
+                text=f"v{result.latest} is available. "
+                     f"You're on v{result.current}.")
+        elif result.status == "error":
+            self.status.configure(
+                text=f"Couldn't reach github.com.\n\n{result.error}")
+        else:
+            self.status.configure(
+                text=f"Update check skipped: {result.error or 'unknown'}.")
+
+    def _open_url(self) -> None:
+        if self._url:
+            try:
+                webbrowser.open(self._url)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+class BackupsDialog(tk.Toplevel):
+    """List every backup of the loaded save and allow restoring any of them."""
+
+    def __init__(self, parent: PCEditGUI, save_path: Path) -> None:
+        super().__init__(parent)
+        self.title(f"Backups for {save_path.name}")
+        self.transient(parent)
+        self.grab_set()
+        self.geometry("520x320")
+        self._parent = parent
+        self._save_path = save_path
+
+        body = ttk.Frame(self, padding=12)
+        body.pack(fill="both", expand=True)
+        ttk.Label(body, text="Newest at the top. Double-click or use the "
+                              "Restore button to roll back.",
+                  foreground="#666", wraplength=480, justify="left").pack(anchor="w")
+
+        list_wrap = ttk.Frame(body)
+        list_wrap.pack(fill="both", expand=True, pady=(8, 0))
+        self.lb = tk.Listbox(list_wrap, font=("Menlo", 11), activestyle="dotbox")
+        sb = ttk.Scrollbar(list_wrap, orient="vertical", command=self.lb.yview)
+        self.lb.configure(yscrollcommand=sb.set)
+        self.lb.pack(side="left", fill="both", expand=True)
+        sb.pack(side="left", fill="y")
+        self.lb.bind("<Double-1>", lambda _e: self._restore())
+
+        bar = ttk.Frame(body)
+        bar.pack(fill="x", pady=(8, 0))
+        ttk.Button(bar, text="Restore selected",
+                   command=self._restore).pack(side="left")
+        ttk.Button(bar, text="Reveal in folder",
+                   command=self._reveal).pack(side="left", padx=4)
+        ttk.Button(bar, text="Close",
+                   command=self.destroy).pack(side="right")
+
+        self._refresh()
+        self.bind("<Escape>", lambda _e: self.destroy())
+
+    def _refresh(self) -> None:
+        self.lb.delete(0, "end")
+        self._backups = list_backups(self._save_path)
+        if not self._backups:
+            self.lb.insert("end", "(no backups found)")
+            return
+        import datetime as _dt
+        for p in self._backups:
+            ts = _dt.datetime.fromtimestamp(p.stat().st_mtime)
+            tag = "sidecar" if p.parent == self._save_path.parent else "bak/"
+            line = f"{ts.strftime('%Y-%m-%d %H:%M:%S')}   [{tag}]  {p.name}"
+            self.lb.insert("end", line)
+
+    def _selected(self) -> Path | None:
+        idx = self.lb.curselection()
+        if not idx or not self._backups:
+            return None
+        return self._backups[idx[0]]
+
+    def _restore(self) -> None:
+        bak = self._selected()
+        if bak is None:
+            messagebox.showinfo("Restore", "Pick a backup first.", parent=self)
+            return
+        if not messagebox.askyesno(
+                "Restore from backup",
+                f"Replace {self._save_path.name} with {bak.name}?",
+                parent=self):
+            return
+        shutil.copy2(bak, self._save_path)
+        self._parent.load(self._save_path)
+        self._parent.status_var.set(f"restored {self._save_path.name} from {bak.name}")
+        self.destroy()
+
+    def _reveal(self) -> None:
+        bak = self._selected() or (self._backups[0] if self._backups else None)
+        if bak is None:
+            return
+        # Open the containing folder in the OS file manager. Cross-platform
+        # via webbrowser.open on the file:// URL works on macOS and most
+        # Linux file managers; on Windows, fall back to os.startfile.
+        try:
+            if sys.platform.startswith("win"):
+                os.startfile(str(bak.parent))  # type: ignore[attr-defined]
+            else:
+                webbrowser.open(bak.parent.as_uri())
+        except Exception:  # noqa: BLE001
+            pass
 
 
 # --- entry point ------------------------------------------------------------


### PR DESCRIPTION
Closes #20 and #16. New Settings + Help menubar, manual update check (bypasses 24 h cache), bak/ folder layout with timestamped backups (toggle to legacy sidecar via Settings → Backup layout). Browse all backups… dialog. CLI's pcedit undo now finds the latest backup in either layout. Verified end-to-end on the v0.10.25 sample save.