### PR TITLE
Release v0.6.0: Help menu + bak/ folder backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release notes.
 
 ## [Unreleased]
 
+(none)
+
+## [0.6.0] — 2026-05-01
+
 ### Added
 - **Settings + Help menubar.** New top-level **Settings** menu (Update
   check on launch, Backup layout submenu) and **Help** menu (Check for
@@ -218,7 +222,8 @@ Release notes.
   - **Caught Pokémon**: editable table with double-click dialog.
 - Round-trip verified byte-exact on the v0.10.25 sample save.
 
-[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.0...v0.4.1


### PR DESCRIPTION
Promotes [Unreleased] (#20 manual update check, #16 bak/ folder + settings toggle, Browse all backups dialog, About dialog) to [0.6.0].