### PR TITLE
Release v0.7.0: full national-dex names + per-gender stat back-fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Release notes.
 
 ## [Unreleased]
 
+(none)
+
+## [0.7.0] — 2026-05-05
+
 ### Added
 - **Full national-dex names** ([#4](https://github.com/daclink/pokeclicker-save-editor/issues/4)).
   `pokeclicker_data.py` now ships display names for ids 1–1025 (was
@@ -278,7 +282,8 @@ Release notes.
   - **Caught Pokémon**: editable table with double-click dialog.
 - Round-trip verified byte-exact on the v0.10.25 sample save.
 
-[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/daclink/pokeclicker-save-editor/compare/v0.4.1...v0.5.0


### PR DESCRIPTION
Promotes [Unreleased] (#4, #26, AboutDialog polish, fetch script, schema tests, defensive id coercion) to [0.7.0]. After merge, scripts/release.py 0.7.0 cuts the GitHub Release; CI uploads the three platform binaries.