### PR TITLE
Web data layer: load data/*.json + helpers + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,24 @@ Release notes.
   `/pokeclicker-save-editor/` so the production bundle's asset URLs
   resolve correctly when the deploy workflow lands. `VITE_BASE=/`
   overrides for local builds or forks under a different repo name.
+- **`web/src/lib/data.ts`** — TypeScript counterpart to
+  `pokeclicker_data.py`. Reads the same `data/*.json` files the Python
+  shim reads via Vite's static JSON imports (no runtime fetch); exposes
+  `NATIONAL_NAMES`, `BERRY_NAMES`, `MULCH_NAMES`, `REGION_RANGES`,
+  `KANTO_NAMES`, plus `nameFor`/`regionFor`/`statBucketFor`/
+  `nameForBerry`/`nameForMulch` helpers. Import-time invariants mirror
+  the Python module's (`length === 1025`, `BERRY_NAMES` endpoints are
+  `Cheri`…`Hopo`, etc.) so a regenerated `data/` that drifts shape
+  fails the build instead of silently shipping a wrong roster.
+- **`web/tests/data.spec.ts`** — 18 new tests covering roster sizes,
+  special-character display names (Nidoran♀/♂, Farfetch'd, Mr. Mime,
+  Tapu Koko, Type: Null, …), region boundary coverage, gender-bucket
+  spot-checks (legendaries, female-only, male-only species), berry
+  endpoints, and mulch fallback labels. Test count: 6 → 24.
+- **`App.svelte` summary** now resolves `player._region` to its label
+  via `REGION_RANGES` and shows the first three caught species by
+  name via `nameFor(pid)` — minimal end-to-end exercise of the new
+  helpers from the production bundle, not just tree-shaken-out code.
 
 ### Changed
 - **Reference data extracted to `data/*.json`** as the first step of the

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -5,14 +5,16 @@
   // it correctly. Subsequent PRs add the tabs from the desktop editor one
   // at a time. The save never leaves this tab.
   import { decodeBytes } from './lib/save'
+  import { REGION_RANGES, nameFor } from './lib/data'
 
   type SaveSummary = {
     fileName: string
     bytes: number
     townName: string
-    region: number
+    region: string
     caughtCount: number
     money: number
+    sampleCaught: string
   }
 
   let status = $state(
@@ -30,17 +32,28 @@
       const player = (data.player ?? {}) as Record<string, unknown>
       const save = (data.save ?? {}) as Record<string, unknown>
       const party = ((save.party as Record<string, unknown>)?.caughtPokemon ??
-        []) as unknown[]
+        []) as Array<Record<string, unknown>>
       const wallet = (save.wallet as Record<string, unknown>)?.currencies as
         | number[]
         | undefined
+      const regionIdx = (player._region as number) ?? -1
+      const regionLabel =
+        regionIdx >= 0 && regionIdx < REGION_RANGES.length
+          ? REGION_RANGES[regionIdx].label
+          : `region #${regionIdx}`
+      // First three caught species by name — proves the dex roster wired up.
+      const sampleCaught = party
+        .slice(0, 3)
+        .map((p) => `${nameFor(p.id)} (#${p.id})`)
+        .join(', ')
       summary = {
         fileName: file.name,
         bytes: text.length,
         townName: (player._townName as string) ?? '?',
-        region: (player._region as number) ?? -1,
+        region: regionLabel,
         caughtCount: party.length,
         money: wallet?.[0] ?? 0,
+        sampleCaught: sampleCaught || '(none)',
       }
       status = `loaded ${file.name}`
     } catch (e) {
@@ -97,8 +110,9 @@
       <dl>
         <dt>File</dt><dd>{summary.fileName} ({summary.bytes} bytes)</dd>
         <dt>Town</dt><dd>{summary.townName}</dd>
-        <dt>Region id</dt><dd>{summary.region}</dd>
+        <dt>Region</dt><dd>{summary.region}</dd>
         <dt>Caught pokémon</dt><dd>{summary.caughtCount}</dd>
+        <dt>Sample caught</dt><dd>{summary.sampleCaught}</dd>
         <dt>PokéDollars</dt><dd>{summary.money}</dd>
       </dl>
     </section>

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -1,0 +1,142 @@
+/**
+ * Static reference data for the editor — TypeScript counterpart to
+ * `pokeclicker_data.py`.
+ *
+ * Reads the same `data/*.json` files the Python shim reads (one source of
+ * truth for both runtimes). Vite inlines the JSON at build time, so there's
+ * no runtime fetch; the cost is in the bundle (the names table is the
+ * biggest at ~14 KB pretty-printed → ~8 KB minified, well worth it for the
+ * zero-network UX).
+ *
+ * The asserts at the bottom mirror the import-time invariants in
+ * `pokeclicker_data.py`. If `data/*.json` is regenerated and one of them
+ * fails, the build dies loud rather than silently shipping a wrong roster.
+ */
+
+import berryNamesJson from '../../../data/berry-names.json'
+import genderBucketsJson from '../../../data/gender-buckets.json'
+import mulchNamesJson from '../../../data/mulch-names.json'
+import pokemonNamesJson from '../../../data/pokemon-names.json'
+import regionRangesJson from '../../../data/region-ranges.json'
+
+// --- types -----------------------------------------------------------------
+
+export type RegionRange = {
+  readonly label: string
+  readonly lo: number
+  readonly hi: number
+}
+
+export type GenderBucket =
+  | 'totalMalePokemonCaptured'
+  | 'totalFemalePokemonCaptured'
+  | 'totalGenderlessPokemonCaptured'
+
+type GenderBucketsJson = { labels: readonly string[]; index: string }
+
+// --- exported constants ----------------------------------------------------
+
+export const NATIONAL_NAMES: readonly string[] = pokemonNamesJson as readonly string[]
+export const BERRY_NAMES: readonly string[] = berryNamesJson as readonly string[]
+export const MULCH_NAMES: readonly string[] = mulchNamesJson as readonly string[]
+
+// TS sees JSON arrays as `(string | number)[]` rather than tuples, so we
+// cast through `unknown` and trust the shape (the import-time invariants
+// below catch genuine drift).
+export const REGION_RANGES: readonly RegionRange[] = (
+  regionRangesJson as unknown as readonly [string, number, number][]
+).map(([label, lo, hi]) => ({ label, lo, hi }))
+
+const _buckets = genderBucketsJson as GenderBucketsJson
+const BUCKET_LABELS = _buckets.labels as readonly GenderBucket[]
+const BUCKET_INDEX: string = _buckets.index
+
+// Backward-compat alias for callers that still want Kanto only.
+export const KANTO_NAMES: readonly string[] = NATIONAL_NAMES.slice(0, 151)
+
+// --- import-time invariants (parallel to pokeclicker_data.py) --------------
+
+if (NATIONAL_NAMES.length !== 1025) {
+  throw new Error(
+    `national roster is 1025 names, got ${NATIONAL_NAMES.length}`,
+  )
+}
+if (BUCKET_INDEX.length !== NATIONAL_NAMES.length) {
+  throw new Error(
+    `_BUCKET_INDEX length (${BUCKET_INDEX.length}) must match ` +
+      `NATIONAL_NAMES (${NATIONAL_NAMES.length})`,
+  )
+}
+if (BERRY_NAMES.length !== 70) {
+  throw new Error(`berry roster is 70 names, got ${BERRY_NAMES.length}`)
+}
+if (BERRY_NAMES[0] !== 'Cheri' || BERRY_NAMES[BERRY_NAMES.length - 1] !== 'Hopo') {
+  throw new Error(
+    `berry roster endpoints drifted: ${JSON.stringify(BERRY_NAMES[0])} ... ` +
+      JSON.stringify(BERRY_NAMES[BERRY_NAMES.length - 1]),
+  )
+}
+if (MULCH_NAMES.length < 6) {
+  throw new Error(`mulch roster expected >=6 names, got ${MULCH_NAMES.length}`)
+}
+
+// --- helpers (parallel to name_for / region_for / stat_bucket_for / etc.) --
+
+function coerceId(pid: unknown): number | null {
+  if (typeof pid === 'number' && Number.isFinite(pid)) return Math.trunc(pid)
+  if (typeof pid === 'string') {
+    const n = Number(pid)
+    return Number.isFinite(n) ? Math.trunc(n) : null
+  }
+  return null
+}
+
+/** Friendly name for a national-dex id (1-based), or `'?'` if unknown. */
+export function nameFor(pid: unknown): string {
+  const idx = coerceId(pid)
+  if (idx !== null && idx >= 1 && idx <= NATIONAL_NAMES.length) {
+    return NATIONAL_NAMES[idx - 1]
+  }
+  return '?'
+}
+
+/** Region label for a national-dex id, or `'?'` if out of range. */
+export function regionFor(pid: unknown): string {
+  const idx = coerceId(pid)
+  if (idx === null) return '?'
+  for (const { label, lo, hi } of REGION_RANGES) {
+    if (idx >= lo && idx <= hi) return label
+  }
+  return '?'
+}
+
+/**
+ * `save.statistics.<…>` counter key to bump for this species.
+ * Returns `null` outside the table; callers should bump only the
+ * gender-neutral total in that case.
+ */
+export function statBucketFor(pid: unknown): GenderBucket | null {
+  const idx = coerceId(pid)
+  if (idx === null || idx < 1 || idx > BUCKET_INDEX.length) return null
+  const digit = BUCKET_INDEX.charCodeAt(idx - 1) - 48 // '0' = 48
+  return BUCKET_LABELS[digit] ?? null
+}
+
+/** BerryType name for an index into `save.farming.berryList`, or `'?'`. */
+export function nameForBerry(idx: unknown): string {
+  const n = coerceId(idx)
+  if (n !== null && n >= 0 && n < BERRY_NAMES.length) return BERRY_NAMES[n]
+  return '?'
+}
+
+/**
+ * MulchType display name for a `save.farming.mulchList` position. Falls back
+ * to `'Slot N'` for indices beyond the enum (real saves observed in the wild
+ * sometimes carry one extra slot).
+ */
+export function nameForMulch(idx: unknown): string {
+  const n = coerceId(idx)
+  if (n === null || n < 0) return '?'
+  if (n < MULCH_NAMES.length) return MULCH_NAMES[n]
+  return `Slot ${n}`
+}

--- a/web/tests/data.spec.ts
+++ b/web/tests/data.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Sanity-check the reference data loaded from `data/*.json`.
+ *
+ * Mirrors `tests/test_schema.py` (`PokemonDataTest`, `BerryDataTest`):
+ * roster sizes, special-character names, region coverage, bucket validity,
+ * berry endpoints, mulch fallback. One source of truth, two runtimes.
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  BERRY_NAMES,
+  KANTO_NAMES,
+  MULCH_NAMES,
+  NATIONAL_NAMES,
+  REGION_RANGES,
+  nameFor,
+  nameForBerry,
+  nameForMulch,
+  regionFor,
+  statBucketFor,
+} from '../src/lib/data'
+
+describe('national-dex names', () => {
+  test('roster has 1025 entries', () => {
+    expect(NATIONAL_NAMES.length).toBe(1025)
+  })
+
+  test('every name is non-empty', () => {
+    NATIONAL_NAMES.forEach((n, i) => {
+      expect(n, `empty name at index ${i}`).toBeTruthy()
+    })
+  })
+
+  test('special-character display names round-trip from PokeAPI overrides', () => {
+    // Same spot-checks the Python suite makes.
+    const cases: Array<[number, string]> = [
+      [1, 'Bulbasaur'],
+      [29, 'Nidoran♀'],
+      [32, 'Nidoran♂'],
+      [83, "Farfetch'd"],
+      [122, 'Mr. Mime'],
+      [132, 'Ditto'],
+      [151, 'Mew'],
+      [250, 'Ho-Oh'],
+      [439, 'Mime Jr.'],
+      [474, 'Porygon-Z'],
+      [772, 'Type: Null'],
+      [785, 'Tapu Koko'],
+      [865, "Sirfetch'd"],
+      [1025, 'Pecharunt'],
+    ]
+    for (const [pid, expected] of cases) {
+      expect(nameFor(pid), `name mismatch for #${pid}`).toBe(expected)
+    }
+  })
+
+  test('nameFor tolerates float/string ids and unknown values', () => {
+    expect(nameFor(1.0)).toBe('Bulbasaur')
+    expect(nameFor('1')).toBe('Bulbasaur')
+    expect(nameFor(null)).toBe('?')
+    expect(nameFor(undefined)).toBe('?')
+    expect(nameFor(99999)).toBe('?')
+    expect(nameFor(0)).toBe('?')
+  })
+
+  test('KANTO_NAMES is the first 151 entries', () => {
+    expect(KANTO_NAMES.length).toBe(151)
+    expect(KANTO_NAMES[0]).toBe('Bulbasaur')
+    expect(KANTO_NAMES[150]).toBe('Mew')
+  })
+})
+
+describe('regions', () => {
+  test('every range boundary resolves', () => {
+    const ids = [
+      1, 151, 152, 251, 252, 386, 387, 493, 494, 649,
+      650, 721, 722, 809, 810, 905, 906, 1025,
+    ]
+    for (const pid of ids) {
+      expect(regionFor(pid), `region missing for #${pid}`).not.toBe('?')
+    }
+  })
+
+  test('REGION_RANGES is dense over [1, 1025]', () => {
+    expect(REGION_RANGES[0]).toEqual({ label: 'Kanto', lo: 1, hi: 151 })
+    expect(REGION_RANGES[REGION_RANGES.length - 1]).toEqual({
+      label: 'Paldea',
+      lo: 906,
+      hi: 1025,
+    })
+  })
+
+  test('out-of-range ids return "?"', () => {
+    expect(regionFor(0)).toBe('?')
+    expect(regionFor(99999)).toBe('?')
+    expect(regionFor(null)).toBe('?')
+  })
+})
+
+describe('gender buckets', () => {
+  const VALID = new Set([
+    'totalMalePokemonCaptured',
+    'totalFemalePokemonCaptured',
+    'totalGenderlessPokemonCaptured',
+  ])
+
+  test('every id returns a valid label', () => {
+    for (let pid = 1; pid <= NATIONAL_NAMES.length; pid++) {
+      const bucket = statBucketFor(pid)
+      expect(VALID.has(bucket as string), `invalid bucket for #${pid}: ${bucket}`).toBe(true)
+    }
+  })
+
+  test('genderless species spot-checks', () => {
+    // Legendaries / fossils / Magnemite line.
+    const ids = [132, 137, 144, 145, 146, 150, 151, 250, 251, 374, 375, 376,
+                 377, 378, 379, 382, 383, 384, 385, 386, 1025]
+    for (const pid of ids) {
+      expect(statBucketFor(pid), `#${pid} should be genderless`).toBe(
+        'totalGenderlessPokemonCaptured',
+      )
+    }
+  })
+
+  test('female-only species spot-checks', () => {
+    const ids = [29, 30, 31, 113, 115, 124, 238, 241, 242, 380]
+    for (const pid of ids) {
+      expect(statBucketFor(pid), `#${pid} should be female bucket`).toBe(
+        'totalFemalePokemonCaptured',
+      )
+    }
+  })
+
+  test('male-only species spot-checks', () => {
+    const ids = [32, 33, 34, 106, 107, 128, 236, 237, 313, 381]
+    for (const pid of ids) {
+      expect(statBucketFor(pid), `#${pid} should be male bucket`).toBe(
+        'totalMalePokemonCaptured',
+      )
+    }
+  })
+
+  test('out-of-range returns null', () => {
+    expect(statBucketFor(0)).toBeNull()
+    expect(statBucketFor(NATIONAL_NAMES.length + 1)).toBeNull()
+    expect(statBucketFor(99999)).toBeNull()
+  })
+})
+
+describe('berries', () => {
+  test('roster has 70 entries with the expected endpoints', () => {
+    expect(BERRY_NAMES.length).toBe(70)
+    expect(BERRY_NAMES[0]).toBe('Cheri')
+    expect(BERRY_NAMES[BERRY_NAMES.length - 1]).toBe('Hopo')
+  })
+
+  test('every berry name is non-empty', () => {
+    BERRY_NAMES.forEach((n, i) => {
+      expect(n, `empty berry name at index ${i}`).toBeTruthy()
+    })
+  })
+
+  test('nameForBerry handles edges', () => {
+    expect(nameForBerry(0)).toBe(BERRY_NAMES[0])
+    expect(nameForBerry(BERRY_NAMES.length - 1)).toBe(BERRY_NAMES[BERRY_NAMES.length - 1])
+    expect(nameForBerry(-1)).toBe('?')
+    expect(nameForBerry(BERRY_NAMES.length)).toBe('?')
+    expect(nameForBerry('0')).toBe(BERRY_NAMES[0])
+    expect(nameForBerry(null)).toBe('?')
+  })
+})
+
+describe('mulch', () => {
+  test('at least 6 names, Boost first', () => {
+    expect(MULCH_NAMES.length).toBeGreaterThanOrEqual(6)
+    expect(MULCH_NAMES[0]).toBe('Boost')
+  })
+
+  test('nameForMulch falls back to "Slot N" for indices beyond the enum', () => {
+    expect(nameForMulch(0)).toBe(MULCH_NAMES[0])
+    expect(nameForMulch(MULCH_NAMES.length)).toBe(`Slot ${MULCH_NAMES.length}`)
+    expect(nameForMulch(-1)).toBe('?')
+    expect(nameForMulch(null)).toBe('?')
+  })
+})


### PR DESCRIPTION
## Summary

TS counterpart to `pokeclicker_data.py`. The SPA now reads the same `data/*.json` files the Python shim reads, with Vite inlining them at build time — no runtime fetch, no second source of truth.

## What's here

- **`web/src/lib/data.ts`** — exposes `NATIONAL_NAMES`, `BERRY_NAMES`, `MULCH_NAMES`, `REGION_RANGES`, `KANTO_NAMES` plus `nameFor` / `regionFor` / `statBucketFor` / `nameForBerry` / `nameForMulch`. Public surface parallels the Python module so I could later auto-generate one from the other if it's worth it.
- **Import-time invariants** mirror the Python shim's: `NATIONAL_NAMES.length === 1025`, `BERRY_NAMES.length === 70` with endpoints `Cheri`…`Hopo`, `_BUCKET_INDEX.length === NATIONAL_NAMES.length`, `MULCH_NAMES.length >= 6`. A regenerated `data/` that drifts shape fails the build instead of silently shipping a wrong roster.
- **`web/tests/data.spec.ts`** — 18 new tests mirroring `PokemonDataTest` / `BerryDataTest` in `tests/test_schema.py`:
  - Roster sizes + non-empty assertions
  - Special-character display names: Nidoran♀/♂, Farfetch'd, Mr. Mime, Tapu Koko, Type: Null, Ho-Oh, Mime Jr., Porygon-Z, Sirfetch'd, Pecharunt
  - `nameFor` tolerates float/string ids, null/undefined → '?'
  - Region boundaries dense over [1, 1025]
  - Gender-bucket spot-checks: 21 genderless legendaries/fossils/Magnemite line, 10 female-only species (Nidoran-F line, Chansey/Blissey, etc.), 10 male-only species (Nidoran-M line, Hitmon-*, etc.)
  - Berry endpoints + length, mulch fallback `'Slot N'` for indices beyond the enum
- **`App.svelte`** uses the new helpers: resolves `player._region` to its region label via `REGION_RANGES`, and shows the first three caught species by name via `nameFor(pid)`. Proves the data layer wires end-to-end in the production bundle (otherwise the JSON imports tree-shake out).

## Numbers

- Bundle: 32 KB JS / 13 KB gzipped → **46 KB JS / 20 KB gzipped**. The delta is exactly the names tables (1025 entries dominates).
- Tests: 6 → 24. Python suite still 33/33.

## Test plan

- [x] CI green
- [x] Manual: `cd web && npm run dev`, drop a real save, confirm Region shows a label (not a number) and Sample caught shows real species names

## What's next

1. ✅ Skeleton (PR #40, merged)
2. ✅ Data layer (this PR)
3. Currencies & Multipliers tab (smallest tab — validates the load-edit-save loop in the browser)
4. Eggs, Shards, Berries, Caught, Pokédex (one PR each)
5. GitHub Pages deploy workflow + promote the README's WIP "Browser" mention to a real link

🤖 Generated with [Claude Code](https://claude.com/claude-code)