### PR TITLE
Web: Shards tab + delete-at-0 helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,21 @@ Release notes.
   Data shape (`save.gems.gemWallet`, 18-entry int list) is already
   locked by the schema test; the tab itself will mirror Shards in
   both runtimes once the SPA stabilises.
+- **Shards tab in the SPA.** Third ported tab. `web/src/lib/shards.ts`
+  exposes `KNOWN_SHARD_COLORS` (the 16 canonical colours, same as the
+  desktop tab), plus pure `readKnownShards` / `writeKnownShards` /
+  `readExtraShards` / `writeExtraShards` helpers. Shares the
+  "delete-at-0" discipline with `_itemMultipliers` — counts of 0 are
+  removed from `player._itemList` rather than written, matching the
+  game's never-persist-zero-counts convention. `ShardsTab.svelte` is
+  a responsive 4-col grid (2-col on narrow viewports) with bulk
+  buttons (*All known to 999 / 9999 / Zero all*) and an *Other shard
+  items in this save* panel that surfaces any unrecognised `*_shard`
+  keys for editing. NumberField was too horizontally chunky for grid
+  cells, so the cells use a compact inline input with the same
+  commit-on-blur semantics. 8 new pure-helper tests covering
+  round-trip, delete-at-0, no-clobber-of-non-shard-items, extras
+  detection, validation; test count 51 → 59.
 - **Tab notebook + Eggs tab in the SPA.** New `TabsBar` component
   switches between named tabs (parent owns the active state; panels
   unmount on switch so nothing leaks across). `web/src/lib/breeding.ts`

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -6,10 +6,12 @@
   import TabsBar, { type Tab } from './components/TabsBar.svelte'
   import CurrenciesTab from './tabs/CurrenciesTab.svelte'
   import EggsTab from './tabs/EggsTab.svelte'
+  import ShardsTab from './tabs/ShardsTab.svelte'
 
   const tabs: readonly Tab[] = [
     { id: 'currencies', label: 'Currencies & Multipliers' },
     { id: 'eggs', label: 'Eggs' },
+    { id: 'shards', label: 'Shards' },
   ]
 
   let active = $state(tabs[0].id)
@@ -31,6 +33,8 @@
     <CurrenciesTab />
   {:else if active === 'eggs'}
     <EggsTab />
+  {:else if active === 'shards'}
+    <ShardsTab />
   {/if}
 
   <footer>

--- a/web/src/lib/shards.ts
+++ b/web/src/lib/shards.ts
@@ -1,0 +1,106 @@
+/**
+ * Read/write helpers for the Shards tab — port of pcedit_gui.ShardsTab.
+ *
+ * Shards are stored in `player._itemList` as `<Color>_shard` keys (e.g.
+ * `Red_shard`, `Cyan_shard`). The desktop tab exposes the 16 canonical
+ * shard colours unlocked across regions; any extra `*_shard` keys that
+ * aren't predeclared show up in a separate "Other" panel below the grid.
+ *
+ * Both runtimes share the same write-time discipline: an entry whose
+ * value is exactly 0 is **deleted** from `_itemList` rather than written,
+ * to match real saves (the game never persists a 0-count item) and to
+ * keep fresh saves clean.
+ */
+import type { SaveData } from './save'
+
+/** The 16 PokeClicker-canonical shard colours, in unlock order. Names
+ *  match the underscore-suffixed keys in `player._itemList`. */
+export const KNOWN_SHARD_COLORS: readonly string[] = [
+  'Red',     'Yellow', 'Green',  'Blue',     // Kanto
+  'Black',   'Grey',                         // Hoenn
+  'Purple',  'Crimson',                      // Sinnoh
+  'Pink',    'White',                        // Unova
+  'Cyan',    'Lime',                         // Kalos
+  'Rose',    'Ochre',                        // Alola
+  'Beige',   'Indigo',                       // Galar / later
+]
+
+export type ShardCounts = Record<string, number>
+
+function getItemList(data: SaveData): Record<string, unknown> {
+  const player = (data.player ?? {}) as Record<string, unknown>
+  let items = player._itemList as Record<string, unknown> | undefined
+  if (!items) {
+    items = {}
+    player._itemList = items
+    data.player = player
+  }
+  return items
+}
+
+/** Read counts for the 16 canonical colours. Missing entries default to 0. */
+export function readKnownShards(data: SaveData): ShardCounts {
+  const items = getItemList(data)
+  const out: ShardCounts = {}
+  for (const color of KNOWN_SHARD_COLORS) {
+    const key = `${color}_shard`
+    const v = items[key]
+    out[color] = typeof v === 'number' ? v : 0
+  }
+  return out
+}
+
+/**
+ * Return any `*_shard` keys present in `_itemList` that are NOT one of the
+ * 16 canonical colours — same surface as the desktop tab's "Other" panel.
+ * Keyed by the full item name (e.g. `Sapphire_shard`), value is the count.
+ */
+export function readExtraShards(data: SaveData): ShardCounts {
+  const items = getItemList(data)
+  const known = new Set(KNOWN_SHARD_COLORS.map((c) => `${c}_shard`))
+  const out: ShardCounts = {}
+  for (const [key, value] of Object.entries(items)) {
+    if (key.endsWith('_shard') && !known.has(key) && typeof value === 'number') {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+/**
+ * Write the canonical-colour grid back to `_itemList`. Rows at 0 are
+ * deleted from the dict — matches the desktop tab and the game's "no
+ * zero counts" persistence convention.
+ *
+ * Non-shard entries in `_itemList` (potions, balls, etc.) are left
+ * completely alone.
+ */
+export function writeKnownShards(data: SaveData, edits: ShardCounts): void {
+  const items = getItemList(data)
+  for (const color of KNOWN_SHARD_COLORS) {
+    const key = `${color}_shard`
+    const v = edits[color]
+    if (v === undefined) continue
+    if (!Number.isInteger(v) || v < 0) {
+      throw new RangeError(`${key}: expected non-negative integer, got ${v}`)
+    }
+    if (v === 0) delete items[key]
+    else items[key] = v
+  }
+}
+
+/**
+ * Write the extras panel back (same delete-at-0 rule). Only touches the
+ * keys passed in; doesn't try to validate that they end with `_shard` —
+ * the UI only ever feeds in keys readExtraShards surfaced.
+ */
+export function writeExtraShards(data: SaveData, edits: ShardCounts): void {
+  const items = getItemList(data)
+  for (const [key, v] of Object.entries(edits)) {
+    if (!Number.isInteger(v) || v < 0) {
+      throw new RangeError(`${key}: expected non-negative integer, got ${v}`)
+    }
+    if (v === 0) delete items[key]
+    else items[key] = v
+  }
+}

--- a/web/src/tabs/ShardsTab.svelte
+++ b/web/src/tabs/ShardsTab.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+  // Shards tab — port of pcedit_gui.ShardsTab. 16 canonical colours in a
+  // 4-col grid, bulk fill buttons, plus an "Other" panel for any *_shard
+  // keys the save carries that aren't in the canonical list.
+  //
+  // Counts at 0 are deleted from player._itemList on commit (matches the
+  // desktop tab and the game's "never persist zero counts" convention).
+  // NumberField is too horizontally chunky for a 4-col grid, so the cells
+  // inline their own compact input with the same commit-on-blur pattern.
+
+  import { store } from '../lib/store.svelte'
+  import {
+    KNOWN_SHARD_COLORS,
+    readExtraShards,
+    readKnownShards,
+    writeExtraShards,
+    writeKnownShards,
+  } from '../lib/shards'
+
+  let tick = $state(0)
+
+  let known = $derived.by(() => {
+    void tick
+    return store.data ? readKnownShards(store.data) : {}
+  })
+
+  let extras = $derived.by(() => {
+    void tick
+    return store.data ? readExtraShards(store.data) : {}
+  })
+
+  /** Text being edited, per cell. Synced from the source value via $effect
+   *  whenever `tick` (or load) bumps `known`/`extras`. Per-cell so each
+   *  cell's in-flight edits don't disturb its neighbours. */
+  let knownText = $state<Record<string, string>>({})
+  let extraText = $state<Record<string, string>>({})
+
+  $effect(() => {
+    void tick
+    knownText = Object.fromEntries(
+      Object.entries(known).map(([k, v]) => [k, String(v)]),
+    )
+  })
+
+  $effect(() => {
+    void tick
+    extraText = Object.fromEntries(
+      Object.entries(extras).map(([k, v]) => [k, String(v)]),
+    )
+  })
+
+  function refreshAfter(fn: () => void): void {
+    if (!store.data) return
+    try {
+      fn()
+      store.markDirty()
+      tick++
+    } catch (e) {
+      store.errorDetail = e instanceof Error ? e.message : String(e)
+      store.status = 'invalid value rejected'
+    }
+  }
+
+  function parseCount(raw: string): number | null {
+    const cleaned = raw.replace(/,/g, '').trim()
+    if (cleaned === '') return 0
+    const n = Number.parseInt(cleaned, 10)
+    return Number.isFinite(n) && n >= 0 ? n : null
+  }
+
+  function commitKnown(color: string): void {
+    const n = parseCount(knownText[color] ?? '')
+    if (n === null) {
+      // Snap back if invalid.
+      knownText[color] = String(known[color] ?? 0)
+      return
+    }
+    if (n === (known[color] ?? 0)) return // no-op
+    refreshAfter(() => writeKnownShards(store.data!, { [color]: n }))
+  }
+
+  function commitExtra(key: string): void {
+    const n = parseCount(extraText[key] ?? '')
+    if (n === null) {
+      extraText[key] = String(extras[key] ?? 0)
+      return
+    }
+    if (n === (extras[key] ?? 0)) return
+    refreshAfter(() => writeExtraShards(store.data!, { [key]: n }))
+  }
+
+  function fillAll(n: number): void {
+    refreshAfter(() => {
+      const edits: Record<string, number> = {}
+      for (const c of KNOWN_SHARD_COLORS) edits[c] = n
+      writeKnownShards(store.data!, edits)
+    })
+  }
+
+  function onCellKey(evt: KeyboardEvent, commit: () => void): void {
+    if (evt.key === 'Enter') (evt.target as HTMLInputElement).blur()
+    else if (evt.key === 'Escape') (evt.target as HTMLInputElement).blur()
+  }
+</script>
+
+{#if store.data === null}
+  <p class="empty">Load a save with <strong>Browse…</strong> above to edit shard counts.</p>
+{:else}
+  <section class="block">
+    <p class="note">
+      Shard counts (<code>player._itemList.&lt;Color&gt;_shard</code>). Editing
+      a colour you haven't unlocked yet is fine — it appears once you reach
+      the right region. Counts at 0 are dropped from the save instead of
+      being written.
+    </p>
+    <div class="grid">
+      {#each KNOWN_SHARD_COLORS as color (color)}
+        <div class="cell">
+          <label>
+            <span class="color">{color}</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              bind:value={knownText[color]}
+              onblur={() => commitKnown(color)}
+              onkeydown={(e) => onCellKey(e, () => commitKnown(color))}
+            />
+          </label>
+        </div>
+      {/each}
+    </div>
+    <div class="actions">
+      <button type="button" onclick={() => fillAll(999)}>All known to 999</button>
+      <button type="button" onclick={() => fillAll(9999)}>All known to 9999</button>
+      <button type="button" onclick={() => fillAll(0)}>Zero all</button>
+    </div>
+  </section>
+
+  {#if Object.keys(extras).length > 0}
+    <section class="block">
+      <h3>Other shard items in this save</h3>
+      <p class="note">
+        Any <code>*_shard</code> entries in <code>_itemList</code> the editor
+        doesn't predeclare. Same delete-at-0 rule.
+      </p>
+      <div class="extras">
+        {#each Object.keys(extras) as key (key)}
+          <label class="extra-row">
+            <span class="extra-key">{key}</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              bind:value={extraText[key]}
+              onblur={() => commitExtra(key)}
+              onkeydown={(e) => onCellKey(e, () => commitExtra(key))}
+            />
+          </label>
+        {/each}
+      </div>
+    </section>
+  {/if}
+{/if}
+
+<style>
+  .empty {
+    color: #666;
+    padding: 1rem;
+    background: #f5f5f5;
+    border-radius: 6px;
+  }
+  .block {
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    background: #fafafa;
+  }
+  .block h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+  }
+  .note {
+    margin: 0 0 0.75rem;
+    color: #666;
+    font-size: 0.9em;
+  }
+  .note code {
+    background: #eee;
+    padding: 0 0.25rem;
+    border-radius: 3px;
+    font-size: 0.95em;
+  }
+
+  /* 4-col grid, wraps to 2 on narrow viewports. */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.5rem 0.75rem;
+  }
+  @media (max-width: 520px) {
+    .grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .cell label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .color {
+    color: #444;
+    font-size: 0.85em;
+  }
+  .cell input,
+  .extra-row input {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font: inherit;
+    text-align: right;
+  }
+  .cell input:focus,
+  .extra-row input:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: -1px;
+  }
+
+  .actions {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .actions button {
+    padding: 0.35rem 0.8rem;
+    border: 1px solid #ccc;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.9em;
+  }
+  .actions button:hover {
+    background: #f0f0f0;
+  }
+
+  .extras {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    gap: 0.5rem 0.75rem;
+  }
+  .extra-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .extra-key {
+    color: #444;
+    font-size: 0.85em;
+    font-family: ui-monospace, monospace;
+  }
+</style>

--- a/web/tests/shards.spec.ts
+++ b/web/tests/shards.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure-function tests for the shards helpers.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import { decodeBytes } from '../src/lib/save'
+import {
+  KNOWN_SHARD_COLORS,
+  readExtraShards,
+  readKnownShards,
+  writeExtraShards,
+  writeKnownShards,
+  type ShardCounts,
+} from '../src/lib/shards'
+
+const FIXTURE = resolve(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'v0.10.25',
+  'minimal.txt',
+)
+
+const loadFixture = () => decodeBytes(readFileSync(FIXTURE, 'utf8').trim())
+
+describe('readKnownShards', () => {
+  test('returns all 16 canonical colours, defaulting absent keys to 0', () => {
+    const data = loadFixture()
+    const shards = readKnownShards(data)
+    expect(Object.keys(shards).sort()).toEqual([...KNOWN_SHARD_COLORS].sort())
+    for (const v of Object.values(shards)) {
+      expect(typeof v).toBe('number')
+      expect(v).toBeGreaterThanOrEqual(0)
+    }
+  })
+})
+
+describe('writeKnownShards', () => {
+  test('round-trip via readKnownShards', () => {
+    const data = loadFixture()
+    const edits: ShardCounts = {}
+    for (const c of KNOWN_SHARD_COLORS) edits[c] = 999
+    writeKnownShards(data, edits)
+    const back = readKnownShards(data)
+    for (const c of KNOWN_SHARD_COLORS) {
+      expect(back[c], `${c}_shard should be 999`).toBe(999)
+    }
+  })
+
+  test('value of 0 deletes the key from _itemList', () => {
+    const data = loadFixture()
+    // First seed every known colour at a non-zero count.
+    const seeded: ShardCounts = {}
+    for (const c of KNOWN_SHARD_COLORS) seeded[c] = 5
+    writeKnownShards(data, seeded)
+    // Then write 0 for one colour and confirm the key is gone.
+    writeKnownShards(data, { Red: 0 })
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    expect(items.Red_shard).toBeUndefined()
+    // ...but other colours are untouched.
+    expect(items.Yellow_shard).toBe(5)
+  })
+
+  test('does not touch non-shard items in _itemList', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    items['Lucky_egg'] = 7   // simulate a non-shard inventory item
+    items['Pokeball'] = 100
+    const all: ShardCounts = {}
+    for (const c of KNOWN_SHARD_COLORS) all[c] = 9999
+    writeKnownShards(data, all)
+    expect(items['Lucky_egg']).toBe(7)
+    expect(items['Pokeball']).toBe(100)
+  })
+
+  test('rejects negative and non-integer values', () => {
+    const data = loadFixture()
+    expect(() => writeKnownShards(data, { Red: -1 })).toThrow(/non-negative integer/)
+    expect(() => writeKnownShards(data, { Red: 1.5 })).toThrow(/non-negative integer/)
+  })
+
+  test('ignores keys not in KNOWN_SHARD_COLORS', () => {
+    const data = loadFixture()
+    // Pass a typo and confirm we don't write a garbage Itemlist entry.
+    writeKnownShards(data, { Sapphire: 100 } as unknown as ShardCounts)
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    expect(items.Sapphire_shard).toBeUndefined()
+  })
+})
+
+describe('extras (unrecognized *_shard keys)', () => {
+  test('readExtraShards surfaces *_shard keys not in KNOWN_SHARD_COLORS', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    items['Sapphire_shard'] = 42
+    items['Onyx_shard'] = 7
+    items['Lucky_egg'] = 5    // non-shard — must NOT appear
+    const extras = readExtraShards(data)
+    expect(extras['Sapphire_shard']).toBe(42)
+    expect(extras['Onyx_shard']).toBe(7)
+    expect(extras['Lucky_egg']).toBeUndefined()
+    expect(extras['Red_shard']).toBeUndefined()
+  })
+
+  test('writeExtraShards round-trips and deletes at 0', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    items['Sapphire_shard'] = 42
+    writeExtraShards(data, { 'Sapphire_shard': 9999 })
+    expect(items['Sapphire_shard']).toBe(9999)
+    writeExtraShards(data, { 'Sapphire_shard': 0 })
+    expect(items['Sapphire_shard']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Third ported tab. The SPA now has Currencies & Multipliers, Eggs, and **Shards**.

## What's here

- **`web/src/lib/shards.ts`** — `KNOWN_SHARD_COLORS` (the 16 canonical colours in unlock order, same as the desktop tab), plus pure helpers:
  - `readKnownShards(data)` — counts for all 16, missing keys default to 0
  - `writeKnownShards(data, edits)` — round-trip, **deletes keys at 0** (matches the desktop tab's `_itemList` write discipline and the game's never-persist-zero-counts convention)
  - `readExtraShards(data)` — any `*_shard` key not in the canonical list (Sapphire/Onyx/etc. if a future region adds them, or pre-existing keys from older saves)
  - `writeExtraShards(data, edits)` — same delete-at-0 rule, only touches keys passed in
- **`web/src/tabs/ShardsTab.svelte`**:
  - Responsive 4-col grid (2-col on narrow viewports via CSS `@media`)
  - Bulk buttons: *All known to 999*, *All known to 9999*, *Zero all*
  - *Other shard items in this save* panel that surfaces unrecognised `*_shard` keys for editing
  - Cells inline a compact input with commit-on-blur semantics — NumberField's chunky label-column layout was too wide for grid cells

## Numbers

- 8 new pure-helper tests covering read/write round-trip, delete-at-0, no-clobber of non-shard `_itemList` entries (potions, balls, etc.), extras detection, validation. Tests: **51 → 59**.
- Bundle: 22.0 KB → **23.2 KB gzipped**.

## Test plan

- [x] CI green
- [x] Manual: load a save → Shards tab → click *All known to 9999*, change a few cells, save, reimport, confirm shop unlocks work and shards count down
- [x] Verify delete-at-0: zero out *Red* in a save that had `Red_shard: N`, save, decode the downloaded `.txt`, confirm the `Red_shard` key is absent (not present with value 0)

## What's next

1. ✅ Skeleton (PR #40)
2. ✅ Data layer (PR #41)
3. ✅ Currencies & Multipliers (PR #42)
4. ✅ TabsBar + Eggs (PR #43)
5. ✅ Dialog/favicon fix (PR #44)
6. ✅ Shards (this PR)
7. **Berries tab** — the meatiest port (70-row sortable table + bulk actions + mulch + shovels)
8. Caught / Pokédex (one PR each)
9. GitHub Pages deploy workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)