### PR TITLE
Web: Caught Pokémon tab — sortable + single-select + edit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,24 @@ Release notes.
   Data shape (`save.gems.gemWallet`, 18-entry int list) is already
   locked by the schema test; the tab itself will mirror Shards in
   both runtimes once the SPA stabilises.
+- **Caught Pokémon tab in the SPA.** Fifth ported tab. `web/src/lib/caught.ts`
+  exposes `readCaughtRows` (one row per entry with `nameFor` lookup),
+  `setCaughtEntry` (patch + numeric validation), plus bulk helpers
+  `setCaughtAtkBonus`, `setCaughtResistant`, `setCaughtInEgg`. The
+  helpers preserve the **key-present-iff-true** rule from the desktop
+  tab: setting `inEgg` or `resistant` to `false` *removes* the
+  optional `"4"` / `"5"` keys from the entry rather than writing
+  `false`, matching how real saves serialise those flags and keeping
+  byte-clean round-trips. `CaughtTab.svelte` mirrors the desktop's
+  single-select Treeview: sortable columns (numeric for ID /
+  atkBonus / pokerus / exp; string for Name; bool for the two flags),
+  click-to-select, double-click to edit, action bar with *Edit
+  selected…* / *Mark resistant* / *Clear resistant* /
+  *Set atkBonus 100*. Edit dialog uses an inline native `<dialog>`
+  with the existing `NumberField` (in compact 11-rem mode) plus the
+  two checkboxes. 13 new pure-helper tests; test count 75 → 88.
+  Bundle 33 → 35 KB gzipped — the Caught tab reuses sort and
+  NumberField, so it adds less than Berries did.
 - **Berries tab in the SPA.** Fourth ported tab — meatiest port so far.
   `web/src/lib/berries.ts` covers `save.farming` end-to-end:
   `readBerryRows` (one row per `BerryType` entry, missing slots default

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -8,12 +8,14 @@
   import EggsTab from './tabs/EggsTab.svelte'
   import ShardsTab from './tabs/ShardsTab.svelte'
   import BerriesTab from './tabs/BerriesTab.svelte'
+  import CaughtTab from './tabs/CaughtTab.svelte'
 
   const tabs: readonly Tab[] = [
     { id: 'currencies', label: 'Currencies & Multipliers' },
     { id: 'eggs', label: 'Eggs' },
     { id: 'shards', label: 'Shards' },
     { id: 'berries', label: 'Berries' },
+    { id: 'caught', label: 'Caught Pokémon' },
   ]
 
   let active = $state(tabs[0].id)
@@ -39,6 +41,8 @@
     <ShardsTab />
   {:else if active === 'berries'}
     <BerriesTab />
+  {:else if active === 'caught'}
+    <CaughtTab />
   {/if}
 
   <footer>

--- a/web/src/lib/caught.ts
+++ b/web/src/lib/caught.ts
@@ -1,0 +1,186 @@
+/**
+ * Read/write helpers for the Caught Pokémon tab — port of
+ * pcedit_gui.CaughtTab and CaughtDialog.
+ *
+ * Save shape (under `save.party.caughtPokemon`):
+ *
+ *   [
+ *     {
+ *       id:  pokédex id (int),
+ *       "0": attack bonus from hatching (25 = first hatch tier),
+ *       "1": pokerus state (0..4),
+ *       "2": EVs by attack type (dict; the editor does not touch this),
+ *       "3": total exp,
+ *       "4": (optional bool) currently in egg / breeding-pending,
+ *       "5": (optional bool) resistant flag,
+ *     },
+ *     ...
+ *   ]
+ *
+ * The desktop tab preserves the "key absent" vs "value false" distinction
+ * for the `4` and `5` flags: setting either to false **removes** the key.
+ * That matches what real saves look like (the game writes the keys only
+ * when the flags are true) and keeps round-trips clean. We mirror that
+ * here.
+ */
+import { nameFor } from './data'
+import type { SaveData } from './save'
+
+// --- types ------------------------------------------------------------------
+
+export type CaughtRow = {
+  id: number
+  name: string
+  atkBonus: number   // "0"
+  pokerus: number    // "1"
+  exp: number        // "3"
+  inEgg: boolean     // "4" — true iff key present and truthy
+  resistant: boolean // "5" — true iff key present and truthy
+}
+
+/** Patch shape applied by the edit dialog. Optional fields are skipped. */
+export type CaughtPatch = {
+  atkBonus?: number
+  pokerus?: number
+  exp?: number
+  inEgg?: boolean
+  resistant?: boolean
+}
+
+// --- accessors --------------------------------------------------------------
+
+function getParty(data: SaveData): Array<Record<string, unknown>> {
+  const save = data.save as Record<string, unknown> | undefined
+  const party = save?.party as Record<string, unknown> | undefined
+  const list = party?.caughtPokemon as Array<Record<string, unknown>> | undefined
+  if (!Array.isArray(list)) {
+    throw new Error('save.party.caughtPokemon is missing or not an array')
+  }
+  return list
+}
+
+function findEntry(
+  data: SaveData,
+  id: number,
+): Record<string, unknown> | null {
+  for (const entry of getParty(data)) {
+    if (entry && entry.id === id) return entry
+  }
+  return null
+}
+
+function requireEntry(data: SaveData, id: number): Record<string, unknown> {
+  const entry = findEntry(data, id)
+  if (!entry) throw new RangeError(`no caught pokémon with id ${id}`)
+  return entry
+}
+
+function asInt(v: unknown): number {
+  // Saves occasionally serialise ints as floats; truncate defensively.
+  if (typeof v === 'number' && Number.isFinite(v)) return Math.trunc(v)
+  return 0
+}
+
+function ensureNonNegInt(name: string, v: number): void {
+  if (!Number.isInteger(v) || v < 0) {
+    throw new RangeError(`${name}: expected non-negative integer, got ${v}`)
+  }
+}
+
+// --- public reads -----------------------------------------------------------
+
+export function readCaughtRows(data: SaveData): CaughtRow[] {
+  const out: CaughtRow[] = []
+  for (const entry of getParty(data)) {
+    if (!entry || typeof entry !== 'object') continue
+    const id = typeof entry.id === 'number' ? entry.id : Number(entry.id)
+    if (!Number.isFinite(id)) continue
+    out.push({
+      id,
+      name: nameFor(id),
+      atkBonus: asInt(entry['0']),
+      pokerus: asInt(entry['1']),
+      exp: asInt(entry['3']),
+      inEgg: Boolean(entry['4']),
+      resistant: Boolean(entry['5']),
+    })
+  }
+  return out
+}
+
+// --- public writes ----------------------------------------------------------
+
+/**
+ * Apply a patch to a single caught entry. Numeric fields get written
+ * straight; `inEgg` and `resistant` follow the desktop's
+ * key-present-iff-true rule.
+ */
+export function setCaughtEntry(
+  data: SaveData,
+  id: number,
+  patch: CaughtPatch,
+): void {
+  const entry = requireEntry(data, id)
+  if (patch.atkBonus !== undefined) {
+    ensureNonNegInt('atkBonus', patch.atkBonus)
+    entry['0'] = patch.atkBonus
+  }
+  if (patch.pokerus !== undefined) {
+    ensureNonNegInt('pokerus', patch.pokerus)
+    entry['1'] = patch.pokerus
+  }
+  if (patch.exp !== undefined) {
+    ensureNonNegInt('exp', patch.exp)
+    entry['3'] = patch.exp
+  }
+  if (patch.inEgg !== undefined) {
+    if (patch.inEgg) entry['4'] = true
+    else delete entry['4']
+  }
+  if (patch.resistant !== undefined) {
+    if (patch.resistant) entry['5'] = true
+    else delete entry['5']
+  }
+}
+
+/** Bulk: set `resistant` on multiple ids. Off → delete the key (no `false`). */
+export function setCaughtResistant(
+  data: SaveData,
+  ids: number[],
+  on: boolean,
+): void {
+  for (const id of ids) {
+    const entry = findEntry(data, id)
+    if (!entry) continue // tolerate missing ids — saves can change between renders
+    if (on) entry['5'] = true
+    else delete entry['5']
+  }
+}
+
+/** Bulk: set `inEgg` on multiple ids. Off → delete the key. */
+export function setCaughtInEgg(
+  data: SaveData,
+  ids: number[],
+  on: boolean,
+): void {
+  for (const id of ids) {
+    const entry = findEntry(data, id)
+    if (!entry) continue
+    if (on) entry['4'] = true
+    else delete entry['4']
+  }
+}
+
+/** Bulk: set `atkBonus` on multiple ids. */
+export function setCaughtAtkBonus(
+  data: SaveData,
+  ids: number[],
+  n: number,
+): void {
+  ensureNonNegInt('atkBonus', n)
+  for (const id of ids) {
+    const entry = findEntry(data, id)
+    if (!entry) continue
+    entry['0'] = n
+  }
+}

--- a/web/src/tabs/CaughtTab.svelte
+++ b/web/src/tabs/CaughtTab.svelte
@@ -1,0 +1,405 @@
+<script lang="ts">
+  // Caught Pokémon tab — port of pcedit_gui.CaughtTab + CaughtDialog.
+  //
+  // Click a row to select it. Action bar applies to the selected row only
+  // (mirrors the desktop's single-select Treeview). Click again to deselect.
+  // Sortable column headers; numeric columns sort numerically.
+
+  import { store } from '../lib/store.svelte'
+  import {
+    readCaughtRows,
+    setCaughtAtkBonus,
+    setCaughtEntry,
+    setCaughtResistant,
+    type CaughtPatch,
+    type CaughtRow,
+  } from '../lib/caught'
+  import NumberField from '../components/NumberField.svelte'
+
+  // --- reactive state ----------------------------------------------------
+
+  let tick = $state(0)
+  let selectedId = $state<number | null>(null)
+
+  type SortCol = 'id' | 'name' | 'atkBonus' | 'pokerus' | 'exp' | 'inEgg' | 'resistant'
+  let sortCol = $state<SortCol>('id')
+  let sortReverse = $state(false)
+
+  const NUMERIC_COLS: ReadonlySet<SortCol> = new Set(['id', 'atkBonus', 'pokerus', 'exp'])
+  const BOOL_COLS: ReadonlySet<SortCol> = new Set(['inEgg', 'resistant'])
+
+  let rows = $derived.by<CaughtRow[]>(() => {
+    void tick
+    return store.data ? readCaughtRows(store.data) : []
+  })
+
+  let viewRows = $derived.by<CaughtRow[]>(() => {
+    const out = rows.slice()
+    out.sort((a, b) => {
+      let av: number | string
+      let bv: number | string
+      if (BOOL_COLS.has(sortCol)) {
+        av = a[sortCol] ? 1 : 0
+        bv = b[sortCol] ? 1 : 0
+      } else if (NUMERIC_COLS.has(sortCol)) {
+        av = a[sortCol] as number
+        bv = b[sortCol] as number
+      } else {
+        av = String(a[sortCol])
+        bv = String(b[sortCol])
+      }
+      if (av < bv) return sortReverse ? 1 : -1
+      if (av > bv) return sortReverse ? -1 : 1
+      return 0
+    })
+    return out
+  })
+
+  let selectedRow = $derived(
+    selectedId !== null ? rows.find((r) => r.id === selectedId) ?? null : null,
+  )
+
+  // --- mutation plumbing -------------------------------------------------
+
+  function refreshAfter(fn: () => void): void {
+    if (!store.data) return
+    try {
+      fn()
+      store.markDirty()
+      tick++
+    } catch (e) {
+      store.errorDetail = e instanceof Error ? e.message : String(e)
+      store.status = 'invalid value rejected'
+    }
+  }
+
+  function toggleSort(col: SortCol): void {
+    if (sortCol === col) sortReverse = !sortReverse
+    else {
+      sortCol = col
+      sortReverse = false
+    }
+  }
+
+  function sortIndicator(col: SortCol): string {
+    if (sortCol !== col) return ''
+    return sortReverse ? ' ↓' : ' ↑'
+  }
+
+  function selectRow(id: number): void {
+    selectedId = selectedId === id ? null : id
+  }
+
+  // --- quick actions -----------------------------------------------------
+
+  function onMarkResistant(): void {
+    if (selectedId === null) return
+    const id = selectedId
+    refreshAfter(() => setCaughtResistant(store.data!, [id], true))
+  }
+  function onClearResistant(): void {
+    if (selectedId === null) return
+    const id = selectedId
+    refreshAfter(() => setCaughtResistant(store.data!, [id], false))
+  }
+  function onAtkBonus100(): void {
+    if (selectedId === null) return
+    const id = selectedId
+    refreshAfter(() => setCaughtAtkBonus(store.data!, [id], 100))
+  }
+
+  // --- edit dialog --------------------------------------------------------
+
+  let dialogEl: HTMLDialogElement | undefined = $state()
+  let draft: CaughtPatch = $state({})
+
+  function openEdit(): void {
+    if (!selectedRow) return
+    draft = {
+      atkBonus: selectedRow.atkBonus,
+      pokerus: selectedRow.pokerus,
+      exp: selectedRow.exp,
+      inEgg: selectedRow.inEgg,
+      resistant: selectedRow.resistant,
+    }
+    dialogEl?.showModal()
+  }
+
+  function closeEdit(): void {
+    dialogEl?.close()
+  }
+
+  function saveEdit(): void {
+    if (selectedId === null) {
+      closeEdit()
+      return
+    }
+    const id = selectedId
+    const patch = { ...draft }
+    refreshAfter(() => setCaughtEntry(store.data!, id, patch))
+    closeEdit()
+  }
+
+  function onRowDoubleClick(id: number): void {
+    selectedId = id
+    queueMicrotask(openEdit)
+  }
+</script>
+
+{#if store.data === null}
+  <p class="empty">Load a save with <strong>Browse…</strong> above to edit caught pokémon.</p>
+{:else}
+  <section class="block">
+    <p class="note">
+      Click a row to select. Double-click to edit. atkBonus increments by 25 per hatch.
+    </p>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th><button type="button" onclick={() => toggleSort('id')}>ID{sortIndicator('id')}</button></th>
+            <th class="name-col"><button type="button" onclick={() => toggleSort('name')}>Name{sortIndicator('name')}</button></th>
+            <th><button type="button" onclick={() => toggleSort('atkBonus')}>atkBonus{sortIndicator('atkBonus')}</button></th>
+            <th><button type="button" onclick={() => toggleSort('pokerus')}>pokerus{sortIndicator('pokerus')}</button></th>
+            <th><button type="button" onclick={() => toggleSort('exp')}>exp{sortIndicator('exp')}</button></th>
+            <th><button type="button" onclick={() => toggleSort('inEgg')}>in egg{sortIndicator('inEgg')}</button></th>
+            <th><button type="button" onclick={() => toggleSort('resistant')}>resistant{sortIndicator('resistant')}</button></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each viewRows as row (row.id)}
+            <tr
+              class:selected={selectedId === row.id}
+              onclick={() => selectRow(row.id)}
+              ondblclick={() => onRowDoubleClick(row.id)}
+            >
+              <td>{row.id}</td>
+              <td class="name-col">{row.name}</td>
+              <td>{row.atkBonus}</td>
+              <td>{row.pokerus}</td>
+              <td>{row.exp}</td>
+              <td>{row.inEgg ? 'yes' : ''}</td>
+              <td>{row.resistant ? 'yes' : ''}</td>
+            </tr>
+          {:else}
+            <tr><td colspan="7" class="muted">(no caught pokémon)</td></tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="actions">
+      <button type="button" onclick={openEdit} disabled={selectedRow === null}>
+        Edit selected…
+      </button>
+      <button type="button" onclick={onMarkResistant} disabled={selectedRow === null}>
+        Mark resistant
+      </button>
+      <button type="button" onclick={onClearResistant} disabled={selectedRow === null}>
+        Clear resistant
+      </button>
+      <button type="button" onclick={onAtkBonus100} disabled={selectedRow === null}>
+        Set atkBonus 100
+      </button>
+    </div>
+  </section>
+
+  <dialog bind:this={dialogEl} aria-labelledby="caught-dialog-title">
+    {#if selectedRow}
+      <h3 id="caught-dialog-title">
+        Edit #{selectedRow.id} {selectedRow.name}
+      </h3>
+
+      <NumberField
+        label="atkBonus (+25 per hatch)"
+        value={draft.atkBonus ?? 0}
+        onCommit={(n) => (draft.atkBonus = n)}
+        labelWidth="11rem"
+      />
+      <NumberField
+        label="pokerus (0=none, 1–4)"
+        value={draft.pokerus ?? 0}
+        onCommit={(n) => (draft.pokerus = n)}
+        labelWidth="11rem"
+      />
+      <NumberField
+        label="exp"
+        value={draft.exp ?? 0}
+        onCommit={(n) => (draft.exp = n)}
+        labelWidth="11rem"
+      />
+
+      <label class="row checkbox">
+        <input
+          type="checkbox"
+          checked={draft.inEgg ?? false}
+          onchange={(e) => (draft.inEgg = (e.target as HTMLInputElement).checked)}
+        />
+        <span>in egg / breeding-pending</span>
+      </label>
+      <label class="row checkbox">
+        <input
+          type="checkbox"
+          checked={draft.resistant ?? false}
+          onchange={(e) => (draft.resistant = (e.target as HTMLInputElement).checked)}
+        />
+        <span>resistant</span>
+      </label>
+
+      <div class="dialog-actions">
+        <button type="button" onclick={closeEdit}>Cancel</button>
+        <button type="button" class="primary" onclick={saveEdit}>OK</button>
+      </div>
+    {/if}
+  </dialog>
+{/if}
+
+<style>
+  .empty {
+    color: #666;
+    padding: 1rem;
+    background: #f5f5f5;
+    border-radius: 6px;
+  }
+  .block {
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    background: #fafafa;
+  }
+  .note {
+    margin: 0 0 0.75rem;
+    color: #666;
+    font-size: 0.9em;
+  }
+
+  /* Table ------------------------------------------------------ */
+  .table-wrap {
+    max-height: 28rem;
+    overflow-y: auto;
+    border: 1px solid #e5e5e5;
+    border-radius: 6px;
+    background: white;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9em;
+  }
+  thead {
+    position: sticky;
+    top: 0;
+    background: #f5f5f5;
+    z-index: 1;
+  }
+  th,
+  td {
+    padding: 0.3rem 0.5rem;
+    text-align: center;
+    border-bottom: 1px solid #eee;
+  }
+  th button {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 500;
+    color: #444;
+    padding: 0;
+  }
+  th button:hover {
+    color: #2563eb;
+  }
+  .name-col {
+    text-align: left;
+  }
+  tbody tr {
+    cursor: pointer;
+    user-select: none;
+  }
+  tbody tr:hover {
+    background: #f8fafc;
+  }
+  tbody tr.selected {
+    background: #eff6ff;
+  }
+  .muted {
+    color: #999;
+    cursor: default;
+  }
+
+  /* Action row ----------------------------------------------- */
+  .actions {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .actions button {
+    padding: 0.35rem 0.8rem;
+    border: 1px solid #ccc;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.9em;
+  }
+  .actions button:hover:not(:disabled) {
+    background: #f0f0f0;
+  }
+  .actions button:disabled {
+    color: #aaa;
+    cursor: not-allowed;
+  }
+
+  /* Dialog --------------------------------------------------- */
+  dialog {
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 1.25rem;
+    width: min(34rem, 92vw);
+    max-height: 85vh;
+    overflow-y: auto;
+    background: white;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  }
+  dialog::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+  }
+  dialog h3 {
+    margin: 0 0 0.75rem;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+  }
+  .row.checkbox {
+    margin-top: 0.25rem;
+  }
+  .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+  .dialog-actions button {
+    padding: 0.4rem 0.9rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font: inherit;
+  }
+  .dialog-actions .primary {
+    background: #2563eb;
+    color: white;
+    border-color: #2563eb;
+  }
+  .dialog-actions .primary:hover {
+    background: #1d4ed8;
+  }
+</style>

--- a/web/tests/caught.spec.ts
+++ b/web/tests/caught.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure-function tests for the caught-pokémon helpers.
+ *
+ * Particular focus on the key-present-iff-true rule for inEgg/resistant —
+ * a regression here would break byte-identity round-trips against real
+ * saves that have never had those flags set.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import { decodeBytes } from '../src/lib/save'
+import {
+  readCaughtRows,
+  setCaughtAtkBonus,
+  setCaughtEntry,
+  setCaughtInEgg,
+  setCaughtResistant,
+} from '../src/lib/caught'
+
+const FIXTURE = resolve(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'v0.10.25',
+  'minimal.txt',
+)
+
+const loadFixture = () => decodeBytes(readFileSync(FIXTURE, 'utf8').trim())
+
+// Convenience: pull the raw save-side entry for a given id so we can check
+// for actual key presence (not just truthiness).
+function rawEntry(data: ReturnType<typeof loadFixture>, id: number): Record<string, unknown> {
+  const list = (data.save as any).party.caughtPokemon as Array<Record<string, unknown>>
+  const e = list.find((x) => x?.id === id)
+  if (!e) throw new Error(`no entry with id ${id} in fixture`)
+  return e
+}
+
+describe('readCaughtRows', () => {
+  test('returns one row per caught pokémon with name lookups', () => {
+    const rows = readCaughtRows(loadFixture())
+    expect(rows.length).toBeGreaterThan(0)
+    for (const r of rows) {
+      expect(typeof r.id).toBe('number')
+      expect(typeof r.name).toBe('string')
+      expect(r.name.length).toBeGreaterThan(0)
+      expect(typeof r.atkBonus).toBe('number')
+      expect(typeof r.exp).toBe('number')
+      expect(typeof r.inEgg).toBe('boolean')
+      expect(typeof r.resistant).toBe('boolean')
+    }
+  })
+
+  test('name lookup uses national-dex names', () => {
+    const rows = readCaughtRows(loadFixture())
+    // Fixture has Charmander (#4) and Pikachu (#25).
+    const byId = new Map(rows.map((r) => [r.id, r]))
+    expect(byId.get(4)?.name).toBe('Charmander')
+    expect(byId.get(25)?.name).toBe('Pikachu')
+  })
+})
+
+describe('setCaughtEntry', () => {
+  test('numeric fields round-trip', () => {
+    const data = loadFixture()
+    setCaughtEntry(data, 4, { atkBonus: 100, pokerus: 3, exp: 1234567 })
+    const row = readCaughtRows(data).find((r) => r.id === 4)!
+    expect(row.atkBonus).toBe(100)
+    expect(row.pokerus).toBe(3)
+    expect(row.exp).toBe(1234567)
+  })
+
+  test('inEgg=true sets the "4" key; inEgg=false deletes it', () => {
+    const data = loadFixture()
+    setCaughtEntry(data, 4, { inEgg: true })
+    expect(rawEntry(data, 4)['4']).toBe(true)
+    setCaughtEntry(data, 4, { inEgg: false })
+    expect('4' in rawEntry(data, 4)).toBe(false)
+  })
+
+  test('resistant=true sets the "5" key; resistant=false deletes it', () => {
+    const data = loadFixture()
+    setCaughtEntry(data, 25, { resistant: true })
+    expect(rawEntry(data, 25)['5']).toBe(true)
+    setCaughtEntry(data, 25, { resistant: false })
+    expect('5' in rawEntry(data, 25)).toBe(false)
+  })
+
+  test('preserves untouched fields and the EVs sub-dict', () => {
+    const data = loadFixture()
+    const before = { ...rawEntry(data, 4) }
+    setCaughtEntry(data, 4, { atkBonus: 50 })
+    const after = rawEntry(data, 4)
+    expect(after['1']).toBe(before['1']) // pokerus untouched
+    expect(after['2']).toEqual(before['2']) // EVs untouched
+    expect(after['3']).toBe(before['3']) // exp untouched
+  })
+
+  test('throws on unknown id', () => {
+    const data = loadFixture()
+    expect(() => setCaughtEntry(data, 99999, { atkBonus: 0 })).toThrow(/no caught/)
+  })
+
+  test('rejects negative or non-integer numerics', () => {
+    const data = loadFixture()
+    expect(() => setCaughtEntry(data, 4, { atkBonus: -1 })).toThrow(/non-negative integer/)
+    expect(() => setCaughtEntry(data, 4, { exp: 1.5 })).toThrow(/non-negative integer/)
+  })
+})
+
+describe('quick-action bulk helpers', () => {
+  test('setCaughtResistant true sets the key, false deletes it', () => {
+    const data = loadFixture()
+    setCaughtResistant(data, [4, 25], true)
+    expect(rawEntry(data, 4)['5']).toBe(true)
+    expect(rawEntry(data, 25)['5']).toBe(true)
+    setCaughtResistant(data, [4, 25], false)
+    expect('5' in rawEntry(data, 4)).toBe(false)
+    expect('5' in rawEntry(data, 25)).toBe(false)
+  })
+
+  test('setCaughtInEgg true sets the key, false deletes it', () => {
+    const data = loadFixture()
+    setCaughtInEgg(data, [4], true)
+    expect(rawEntry(data, 4)['4']).toBe(true)
+    setCaughtInEgg(data, [4], false)
+    expect('4' in rawEntry(data, 4)).toBe(false)
+  })
+
+  test('setCaughtAtkBonus writes to all listed ids', () => {
+    const data = loadFixture()
+    setCaughtAtkBonus(data, [4, 25], 100)
+    const rows = readCaughtRows(data)
+    expect(rows.find((r) => r.id === 4)?.atkBonus).toBe(100)
+    expect(rows.find((r) => r.id === 25)?.atkBonus).toBe(100)
+  })
+
+  test('quick-action helpers tolerate ids missing from the save', () => {
+    const data = loadFixture()
+    // Mix valid and invalid; the valid id should still be written.
+    setCaughtAtkBonus(data, [4, 99999], 25)
+    expect(rawEntry(data, 4)['0']).toBe(25)
+  })
+
+  test('setCaughtAtkBonus rejects negative / non-integer', () => {
+    const data = loadFixture()
+    expect(() => setCaughtAtkBonus(data, [4], -1)).toThrow(/non-negative integer/)
+    expect(() => setCaughtAtkBonus(data, [4], 1.5)).toThrow(/non-negative integer/)
+  })
+})


### PR DESCRIPTION
## Summary

Fifth ported tab. Mirrors `pcedit_gui.CaughtTab` + `CaughtDialog`.

## What's here

### `web/src/lib/caught.ts`
- `readCaughtRows` — one row per entry with `nameFor()` lookup; coerces occasionally-float numeric fields via `Math.trunc`
- `setCaughtEntry(id, patch)` — partial update; writes numeric fields straight, **follows the desktop's key-present-iff-true rule** for `"4"` (inEgg) and `"5"` (resistant): setting either to false **removes** the key rather than writing false. Matches how real saves serialise those flags and keeps byte-clean round-trips.
- Bulk helpers: `setCaughtAtkBonus`, `setCaughtResistant`, `setCaughtInEgg`. All tolerate ids missing from the current save without throwing.

### `CaughtTab.svelte`
- **Sortable** table (ID / Name / atkBonus / pokerus / exp / in egg / resistant). Numeric cols sort numerically; bool cols by truthy=1.
- **Single-row select** via click; click again to deselect; **double-click opens the edit dialog** directly.
- Action bar: *Edit selected…* / *Mark resistant* / *Clear resistant* / *Set atkBonus 100* — disabled when nothing is selected, mirrors desktop muscle memory.
- Edit dialog: inline `<dialog>` with `NumberField` (compact 11-rem mode) for atkBonus / pokerus / exp + two checkboxes for the optional flags. Sticky-header table, scrollable for long lists.

## Numbers

- 13 new pure-helper tests covering name lookup, numeric round-trip, **the key-present-iff-true rule for both flags**, preservation of untouched EVs/exp/etc., unknown-id rejection on `setCaughtEntry`, tolerate-missing-ids on bulk helpers, validation rejection. Tests: **75 → 88**.
- Bundle: 33 KB → **35 KB gzipped** (small delta — Caught reuses `NumberField` and the sort pattern from Berries).

## Test plan

- [ ] CI green
- [ ] Manual: drop a save → Caught tab → sort by exp, find a low-exp entry, double-click to edit, bump exp + flip resistant → save → reimport → confirm changes
- [ ] Verify key-present-iff-true: pick an entry with `resistant: true`, edit to uncheck resistant, save, decode the downloaded `.txt`, confirm the `"5"` key is **absent** (not present with value `false`)
- [ ] *Set atkBonus 100* on a single entry → save → reimport → confirm the in-game attack reflects the bump

## What's next

1. ✅ Skeleton (PR #40)
2. ✅ Data layer (PR #41)
3. ✅ Currencies (PR #42)
4. ✅ TabsBar + Eggs (PR #43)
5. ✅ Dialog/favicon fix (PR #44)
6. ✅ Shards (PR #45)
7. ✅ Berries (PR #46)
8. ✅ Caught (this PR)
9. **Pokédex** — region dropdown + mark-caught (last tab)
10. **GitHub Pages deploy workflow** + README link promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)