### PR TITLE
Web: Flutes tab — checkbox grid + forward-compat extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,24 @@ Release notes.
   Data shape (`save.gems.gemWallet`, 18-entry int list) is already
   locked by the schema test; the tab itself will mirror Shards in
   both runtimes once the SPA stabilises.
+- **Flutes tab in the SPA.** Seventh ported tab. `web/src/lib/flutes.ts`
+  exposes `readKnownFlutes` / `writeKnownFlutes` over the 6 canonical
+  flutes (`Yellow`, `Black`, `Time`, `Red`, `White`, `Blue` — matching
+  `FluteItemType` in PokeClicker's `GameConstants.ts`), with boolean
+  ownership semantics on top of the underlying `<Name>_Flute` int in
+  `player._itemList`. `writeKnownFlutes(true)` writes `1`; `false`
+  deletes the key — same delete-at-0 discipline as shards / berries /
+  the `_itemList` convention in the game. `readExtraFlutes` /
+  `writeExtraFlutes` surface any `*_Flute` keys outside the canonical
+  six as numeric extras, so the six commented-out flutes in source
+  (`Poke`, `Azure`, `Eon`, `Sun`, `Moon`, `Grass`) would round-trip
+  cleanly without code changes if PokeClicker ever enables them. The
+  tab UI mirrors `ShardsTab`'s 2-column grid but with checkboxes
+  (since `FluteItem` declares `maxAmount: 1` — flutes are conceptually
+  owned-or-not) plus a `Give all` / `Drop all` pair. Sits next to the
+  Gems tab in the bar because each active flute consumes one gem/sec
+  from the wallet I just shipped. 9 new pure-helper tests; total web
+  test count 100 → 109.
 - **Gems tab in the SPA.** Sixth ported tab. `web/src/lib/gems.ts` exposes
   `readKnownGems` / `writeKnownGems` against the 18-position
   `save.gems.gemWallet` array (PokemonType enum order: Normal, Fighting,

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -10,12 +10,14 @@
   import BerriesTab from './tabs/BerriesTab.svelte'
   import CaughtTab from './tabs/CaughtTab.svelte'
   import GemsTab from './tabs/GemsTab.svelte'
+  import FlutesTab from './tabs/FlutesTab.svelte'
 
   const tabs: readonly Tab[] = [
     { id: 'currencies', label: 'Currencies & Multipliers' },
     { id: 'eggs', label: 'Eggs' },
     { id: 'shards', label: 'Shards' },
     { id: 'gems', label: 'Gems' },
+    { id: 'flutes', label: 'Flutes' },
     { id: 'berries', label: 'Berries' },
     { id: 'caught', label: 'Caught Pokémon' },
   ]
@@ -43,6 +45,8 @@
     <ShardsTab />
   {:else if active === 'gems'}
     <GemsTab />
+  {:else if active === 'flutes'}
+    <FlutesTab />
   {:else if active === 'berries'}
     <BerriesTab />
   {:else if active === 'caught'}

--- a/web/src/lib/flutes.ts
+++ b/web/src/lib/flutes.ts
@@ -1,0 +1,109 @@
+/**
+ * Read/write helpers for the Flutes tab.
+ *
+ * Flutes are stored in `player._itemList` as `<Name>_Flute` keys, e.g.
+ * `Yellow_Flute`, `Time_Flute`. In PokeClicker `FluteItem` declares
+ * `{ maxAmount: 1 }` — flutes are conceptually owned-or-not, so the
+ * stored int is always 0 or 1 and a missing key means "not owned".
+ *
+ * The 6 enabled flutes (`FluteItemType` in `src/modules/GameConstants.ts`):
+ *   Yellow, Black, Time, Red, White, Blue
+ *
+ * Six more are commented-out in source but reserved as future content
+ * (Poke / Azure / Eon / Sun / Moon / Grass). If any future PokeClicker
+ * release enables them, they'll show up in `readExtraFlutes` and round-
+ * trip via `writeExtraFlutes` without code changes here.
+ *
+ * Same `_itemList` delete-at-0 discipline as shards: setting a flute
+ * to "not owned" removes the key rather than writing 0.
+ */
+import type { SaveData } from './save'
+
+/** The 6 flutes currently enabled in PokeClicker, in source order. */
+export const KNOWN_FLUTES: readonly string[] = [
+  'Yellow', 'Black', 'Time', 'Red', 'White', 'Blue',
+]
+
+/** Boolean ownership for the canonical 6 flutes. */
+export type FluteOwnership = Record<string, boolean>
+
+/** Raw int counts for `*_Flute` keys outside the canonical 6. */
+export type FluteCounts = Record<string, number>
+
+function getItemList(data: SaveData): Record<string, unknown> {
+  const player = (data.player ?? {}) as Record<string, unknown>
+  let items = player._itemList as Record<string, unknown> | undefined
+  if (!items) {
+    items = {}
+    player._itemList = items
+    data.player = player
+  }
+  return items
+}
+
+/**
+ * Read ownership of the 6 canonical flutes. A flute is "owned" iff
+ * its `<Name>_Flute` key is present in `_itemList` with a numeric
+ * value >= 1 (handles the int-vs-bool drift noted in `cmd_berry`).
+ */
+export function readKnownFlutes(data: SaveData): FluteOwnership {
+  const items = getItemList(data)
+  const out: FluteOwnership = {}
+  for (const name of KNOWN_FLUTES) {
+    const v = items[`${name}_Flute`]
+    out[name] = typeof v === 'number' ? v >= 1 : false
+  }
+  return out
+}
+
+/**
+ * Surface any `*_Flute` keys in `_itemList` that aren't one of the
+ * 6 canonical names — future-proofs against the commented-out flutes
+ * in `FluteItemType` being enabled later. Keys map to their raw int
+ * count rather than booleans, in case PokeClicker ever loosens the
+ * `maxAmount: 1` cap.
+ */
+export function readExtraFlutes(data: SaveData): FluteCounts {
+  const items = getItemList(data)
+  const known = new Set(KNOWN_FLUTES.map((n) => `${n}_Flute`))
+  const out: FluteCounts = {}
+  for (const [key, value] of Object.entries(items)) {
+    if (key.endsWith('_Flute') && !known.has(key) && typeof value === 'number') {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+/**
+ * Write ownership back. `true` writes `<Name>_Flute = 1`; `false` deletes
+ * the key entirely, matching the game's "no zero counts in `_itemList`"
+ * persistence convention. Unknown names are ignored (protects against
+ * typo'd UI input).
+ */
+export function writeKnownFlutes(data: SaveData, edits: FluteOwnership): void {
+  const items = getItemList(data)
+  for (const name of KNOWN_FLUTES) {
+    if (!(name in edits)) continue
+    const owned = edits[name]
+    const key = `${name}_Flute`
+    if (owned) items[key] = 1
+    else delete items[key]
+  }
+}
+
+/**
+ * Write the extras panel back. Numeric here so future PokeClicker
+ * flutes can carry counts > 1 if the cap is ever loosened. Same
+ * delete-at-0 rule as `writeKnownFlutes` / the shards helpers.
+ */
+export function writeExtraFlutes(data: SaveData, edits: FluteCounts): void {
+  const items = getItemList(data)
+  for (const [key, v] of Object.entries(edits)) {
+    if (!Number.isInteger(v) || v < 0) {
+      throw new RangeError(`${key}: expected non-negative integer, got ${v}`)
+    }
+    if (v === 0) delete items[key]
+    else items[key] = v
+  }
+}

--- a/web/src/tabs/FlutesTab.svelte
+++ b/web/src/tabs/FlutesTab.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+  // Flutes tab — port of the Shards/Gems pattern, but flutes are
+  // boolean owned/not-owned in the game (`FluteItem` declares
+  // `{ maxAmount: 1 }`), so the UI uses checkboxes and writes 1 on
+  // check / deletes the key on uncheck.
+  //
+  // Each active flute consumes one gem/sec from the gemWallet — same
+  // wallet the Gems tab edits, so this tab pairs naturally with it.
+  // Forward-compat: any `*_Flute` key in `_itemList` that isn't one
+  // of the 6 canonical flutes shows up in an extras panel with a
+  // numeric input, so the six commented-out flutes (Poke, Azure,
+  // Eon, Sun, Moon, Grass) round-trip cleanly if PokeClicker ever
+  // enables them.
+
+  import { store } from '../lib/store.svelte'
+  import {
+    KNOWN_FLUTES,
+    readExtraFlutes,
+    readKnownFlutes,
+    writeExtraFlutes,
+    writeKnownFlutes,
+  } from '../lib/flutes'
+
+  let tick = $state(0)
+
+  let known = $derived.by(() => {
+    void tick
+    return store.data ? readKnownFlutes(store.data) : {}
+  })
+
+  let extras = $derived.by(() => {
+    void tick
+    return store.data ? readExtraFlutes(store.data) : {}
+  })
+
+  let extraText = $state<Record<string, string>>({})
+
+  $effect(() => {
+    void tick
+    extraText = Object.fromEntries(
+      Object.entries(extras).map(([k, v]) => [k, String(v)]),
+    )
+  })
+
+  function refreshAfter(fn: () => void): void {
+    if (!store.data) return
+    try {
+      fn()
+      store.markDirty()
+      tick++
+    } catch (e) {
+      store.errorDetail = e instanceof Error ? e.message : String(e)
+      store.status = 'invalid value rejected'
+    }
+  }
+
+  function toggleKnown(name: string, checked: boolean): void {
+    refreshAfter(() => writeKnownFlutes(store.data!, { [name]: checked }))
+  }
+
+  function fillAll(owned: boolean): void {
+    refreshAfter(() => {
+      const edits: Record<string, boolean> = {}
+      for (const n of KNOWN_FLUTES) edits[n] = owned
+      writeKnownFlutes(store.data!, edits)
+    })
+  }
+
+  function parseCount(raw: string): number | null {
+    const cleaned = raw.replace(/,/g, '').trim()
+    if (cleaned === '') return 0
+    const n = Number.parseInt(cleaned, 10)
+    return Number.isFinite(n) && n >= 0 ? n : null
+  }
+
+  function commitExtra(key: string): void {
+    const n = parseCount(extraText[key] ?? '')
+    if (n === null) {
+      extraText[key] = String(extras[key] ?? 0)
+      return
+    }
+    if (n === (extras[key] ?? 0)) return
+    refreshAfter(() => writeExtraFlutes(store.data!, { [key]: n }))
+  }
+
+  function onCellKey(evt: KeyboardEvent): void {
+    if (evt.key === 'Enter' || evt.key === 'Escape') {
+      (evt.target as HTMLInputElement).blur()
+    }
+  }
+</script>
+
+{#if store.data === null}
+  <p class="empty">Load a save with <strong>Browse…</strong> above to edit flute ownership.</p>
+{:else}
+  <section class="block">
+    <p class="note">
+      Flute ownership (<code>player._itemList.&lt;Name&gt;_Flute</code>).
+      Each flute is owned-or-not — PokeClicker caps it at one. Active
+      flutes consume one gem/sec from the gem wallet, so pairing with
+      the <strong>Gems</strong> tab is common.
+    </p>
+    <ul class="grid">
+      {#each KNOWN_FLUTES as name (name)}
+        <li class="cell">
+          <label>
+            <input
+              type="checkbox"
+              checked={known[name] ?? false}
+              onchange={(e) => toggleKnown(name, (e.currentTarget as HTMLInputElement).checked)}
+            />
+            <span class="flute-name">{name} Flute</span>
+          </label>
+        </li>
+      {/each}
+    </ul>
+    <div class="actions">
+      <button type="button" onclick={() => fillAll(true)}>Give all</button>
+      <button type="button" onclick={() => fillAll(false)}>Drop all</button>
+    </div>
+  </section>
+
+  {#if Object.keys(extras).length > 0}
+    <section class="block">
+      <h3>Other flute items in this save</h3>
+      <p class="note">
+        Any <code>*_Flute</code> entries the editor doesn't predeclare.
+        Future PokeClicker flutes (Poke / Azure / Eon / Sun / Moon /
+        Grass) would land here. Numeric input in case the
+        <code>maxAmount: 1</code> cap is ever loosened.
+      </p>
+      <div class="extras">
+        {#each Object.keys(extras) as key (key)}
+          <label class="extra-row">
+            <span class="extra-key">{key}</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              bind:value={extraText[key]}
+              onblur={() => commitExtra(key)}
+              onkeydown={(e) => onCellKey(e)}
+            />
+          </label>
+        {/each}
+      </div>
+    </section>
+  {/if}
+{/if}
+
+<style>
+  .empty {
+    color: #666;
+    padding: 1rem;
+    background: #f5f5f5;
+    border-radius: 6px;
+  }
+  .block {
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    background: #fafafa;
+  }
+  .block h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+  }
+  .note {
+    margin: 0 0 0.75rem;
+    color: #666;
+    font-size: 0.9em;
+  }
+  .note code {
+    background: #eee;
+    padding: 0 0.25rem;
+    border-radius: 3px;
+    font-size: 0.95em;
+  }
+
+  /* 2-col on wide, 1-col on narrow. With 6 entries that's 3 rows wide
+     or 6 stacked — comfortable either way without feeling sparse. */
+  .grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.4rem 0.75rem;
+  }
+  @media (max-width: 420px) {
+    .grid {
+      grid-template-columns: 1fr;
+    }
+  }
+  .cell label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    cursor: pointer;
+  }
+  .cell input[type='checkbox'] {
+    width: 1.1rem;
+    height: 1.1rem;
+    cursor: pointer;
+  }
+  .flute-name {
+    color: #333;
+  }
+
+  .actions {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .actions button {
+    padding: 0.35rem 0.8rem;
+    border: 1px solid #ccc;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.9em;
+  }
+  .actions button:hover {
+    background: #f0f0f0;
+  }
+
+  .extras {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    gap: 0.5rem 0.75rem;
+  }
+  .extra-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .extra-key {
+    color: #444;
+    font-size: 0.85em;
+    font-family: ui-monospace, monospace;
+  }
+  .extra-row input {
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font: inherit;
+    text-align: right;
+  }
+  .extra-row input:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: -1px;
+  }
+</style>

--- a/web/tests/flutes.spec.ts
+++ b/web/tests/flutes.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure-function tests for the flutes helpers. Mirrors shards.spec.ts:
+ * same `_itemList` storage location, same delete-at-0 discipline, but
+ * with boolean ownership semantics on top of the underlying int values.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import { decodeBytes } from '../src/lib/save'
+import {
+  KNOWN_FLUTES,
+  readExtraFlutes,
+  readKnownFlutes,
+  writeExtraFlutes,
+  writeKnownFlutes,
+  type FluteOwnership,
+} from '../src/lib/flutes'
+
+const FIXTURE = resolve(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'v0.10.25',
+  'minimal.txt',
+)
+
+const loadFixture = () => decodeBytes(readFileSync(FIXTURE, 'utf8').trim())
+
+describe('readKnownFlutes', () => {
+  test('returns all 6 canonical flutes, defaulting absent keys to false', () => {
+    const data = loadFixture()
+    const flutes = readKnownFlutes(data)
+    expect(Object.keys(flutes).sort()).toEqual([...KNOWN_FLUTES].sort())
+    for (const v of Object.values(flutes)) expect(typeof v).toBe('boolean')
+  })
+
+  test('treats any non-zero numeric value as owned', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    items.Yellow_Flute = 1   // canonical "owned"
+    items.Black_Flute = 5    // accommodate the cmd_berry-style int drift
+    items.Red_Flute = 0      // explicit 0 → not owned (and a real save wouldn't keep this)
+    const flutes = readKnownFlutes(data)
+    expect(flutes.Yellow).toBe(true)
+    expect(flutes.Black).toBe(true)
+    expect(flutes.Red).toBe(false)
+    expect(flutes.Blue).toBe(false)   // absent key
+  })
+})
+
+describe('writeKnownFlutes', () => {
+  test('true writes <Name>_Flute = 1; round-trips via readKnownFlutes', () => {
+    const data = loadFixture()
+    const edits: FluteOwnership = {}
+    for (const n of KNOWN_FLUTES) edits[n] = true
+    writeKnownFlutes(data, edits)
+    const back = readKnownFlutes(data)
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    for (const n of KNOWN_FLUTES) {
+      expect(back[n]).toBe(true)
+      expect(items[`${n}_Flute`]).toBe(1)
+    }
+  })
+
+  test('false deletes the key from _itemList', () => {
+    const data = loadFixture()
+    // Seed all flutes as owned, then drop one.
+    const seeded: FluteOwnership = {}
+    for (const n of KNOWN_FLUTES) seeded[n] = true
+    writeKnownFlutes(data, seeded)
+    writeKnownFlutes(data, { Yellow: false })
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    expect(items.Yellow_Flute).toBeUndefined()
+    expect(items.Black_Flute).toBe(1)   // siblings untouched
+  })
+
+  test('does not touch non-flute items in _itemList', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    items.Lucky_egg = 7
+    items.Red_shard = 100
+    const all: FluteOwnership = {}
+    for (const n of KNOWN_FLUTES) all[n] = true
+    writeKnownFlutes(data, all)
+    expect(items.Lucky_egg).toBe(7)
+    expect(items.Red_shard).toBe(100)
+  })
+
+  test('ignores names not in KNOWN_FLUTES', () => {
+    const data = loadFixture()
+    writeKnownFlutes(data, { Sapphire: true } as unknown as FluteOwnership)
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    expect(items.Sapphire_Flute).toBeUndefined()
+  })
+})
+
+describe('extras (*_Flute keys outside KNOWN_FLUTES)', () => {
+  test('readExtraFlutes surfaces future-flute keys', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    // Simulate the commented-out flutes ever being enabled.
+    items.Poke_Flute = 1
+    items.Sun_Flute = 1
+    items.Lucky_egg = 5   // non-flute — must NOT appear
+    const extras = readExtraFlutes(data)
+    expect(extras.Poke_Flute).toBe(1)
+    expect(extras.Sun_Flute).toBe(1)
+    expect(extras.Lucky_egg).toBeUndefined()
+    expect(extras.Yellow_Flute).toBeUndefined()
+  })
+
+  test('writeExtraFlutes round-trips and deletes at 0', () => {
+    const data = loadFixture()
+    const items = (data.player as any)._itemList as Record<string, unknown>
+    items.Poke_Flute = 1
+    writeExtraFlutes(data, { Poke_Flute: 3 })   // future cap might be > 1
+    expect(items.Poke_Flute).toBe(3)
+    writeExtraFlutes(data, { Poke_Flute: 0 })
+    expect(items.Poke_Flute).toBeUndefined()
+  })
+
+  test('writeExtraFlutes rejects negative and non-integer values', () => {
+    const data = loadFixture()
+    expect(() => writeExtraFlutes(data, { Poke_Flute: -1 })).toThrow(/non-negative integer/)
+    expect(() => writeExtraFlutes(data, { Poke_Flute: 1.5 })).toThrow(/non-negative integer/)
+  })
+})


### PR DESCRIPTION
## Summary

- Seventh ported SPA tab. Boolean ownership over the 6 canonical PokeClicker flutes (Yellow, Black, Time, Red, White, Blue) at `player._itemList.<Name>_Flute`. Source: `FluteItemType` in [`src/modules/GameConstants.ts`](https://github.com/pokeclicker/pokeclicker/blob/develop/src/modules/GameConstants.ts).
- Sits between Gems and Berries in the tab bar — each active flute consumes 1 gem/sec from the wallet I just shipped, so the two tabs pair naturally.
- Checkbox UI (since `FluteItem` declares `maxAmount: 1`) over a numeric storage. `true` writes `1`, `false` deletes the key — same delete-at-0 discipline as Shards / Berries.
- Forward-compat: any `*_Flute` keys outside the canonical six land in an extras panel with numeric inputs, so the six commented-out flutes in source (`Poke`, `Azure`, `Eon`, `Sun`, `Moon`, `Grass`) round-trip cleanly without code changes if PokeClicker enables them.
- 9 new pure-helper tests; web test count 100 → 109.

## Test plan

- [x] `npm run check`: 112 files, 0 errors
- [x] `npm run test`: 109/109 pass
- [x] `npm run build`: 36.87 KB gzipped
- [x] Manual: load a save with at least one owned flute (`/Users/drew/Downloads/pokeclicker/[v0.10.25] PokeClicker 2026-05-29 20_48_49.txt` has Yellow/Black/Time), confirm checkboxes match
- [x] Manual: toggle, save, reload — confirm `<Name>_Flute=1` appears/disappears in the JSON

## Follow-ups (memory)

- Currency index mismatch caught during this session — `tokens`/`quest` are swapped vs the canonical `enum Currency` in both runtimes. Affects the next user request ("add battle points currency") — surfacing as a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)