### PR TITLE
Fix swapped wallet indices, add Battle Points + Contest Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Release notes.
 ## [Unreleased]
 
 ### Fixed
+- **Wallet currency indices 1 and 2 were swapped vs canonical PokeClicker.**
+  PCEdit's `CURRENCY` constant historically mapped the slug `tokens`
+  to index 1 and `quest` to index 2, but PokeClicker's
+  `enum Currency` in `src/modules/GameConstants.ts` has `questPoint`
+  at 1 and `dungeonToken` at 2. Both the desktop summary print
+  (`pcedit.py` lines 103–106), the desktop `CurrenciesTab` row labels
+  (`pcedit_gui.py` `CURRENCY_LABELS`), the web `currencies.ts`
+  `CURRENCY_INDEX`, the web `CurrenciesTab.svelte` `CURRENCY_ROWS`,
+  the CLI subcommand wrappers (`cmd_tokens` / `cmd_quest_pts`), and
+  the README's positional-array doc all suffered from the swap. The
+  fix changes only the mapping, not the slugs — `pcedit tokens` /
+  `pcedit quest-points` continue to work, but now write the right
+  slot. Saves you previously edited with the buggy semantics still
+  load fine (storage is positional, only labels are interpretive)
+  but the displayed/edited values will appear under the corrected
+  labels going forward.
 - **Eggs tab edit dialog was clipping fields** on shorter viewports —
   native `<dialog>` was getting capped at viewport height without a
   scrollbar, and the NumberField label column (sized for the wider
@@ -81,6 +97,20 @@ Release notes.
   Data shape (`save.gems.gemWallet`, 18-entry int list) is already
   locked by the schema test; the tab itself will mirror Shards in
   both runtimes once the SPA stabilises.
+- **Battle Points and Contest Tokens — currency slots 5 and 6.**
+  Both runtimes now surface the two trailing slots in
+  `save.wallet.currencies` that the editor previously left untouched:
+  `currencies[5]` (battlePoint, earned at the Battle Frontier) and
+  `currencies[6]` (contestToken, used in BattleCafe). Web shows them
+  as two new rows in the Currencies & Multipliers tab; desktop adds
+  them to `CURRENCY_LABELS` and the summary print. CLI gets three
+  new subcommands: `battle-points` / `contest-tokens` (the two newly
+  surfaced) and `diamonds` (filling a long-standing gap — index 3
+  had no shortcut before). `writeCurrencies` now pads short wallets
+  up to the contest-token slot before writing, so a save predating
+  these positions still round-trips cleanly. Web tests updated
+  (fixture expectations now cover all 7 slots, plus a pad-and-write
+  test).
 - **Flutes tab in the SPA.** Seventh ported tab. `web/src/lib/flutes.ts`
   exposes `readKnownFlutes` / `writeKnownFlutes` over the 6 canonical
   flutes (`Yellow`, `Black`, `Time`, `Red`, `White`, `Blue` — matching

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Top-level shape:
 
 A few observed conventions worth knowing:
 
-- **`save.wallet.currencies`** is positional: `[money, dungeonTokens, questPoints, diamonds, farmPoints, battlePoints]`.
+- **`save.wallet.currencies`** is positional, matching PokeClicker's `enum Currency`: `[money, questPoints, dungeonTokens, diamonds, farmPoints, battlePoints, contestTokens]`.
 - **`save.party.caughtPokemon[i]`** is a dict whose keys are integer-strings:
   - `"0"` — attack bonus from hatching (25 = first hatch tier).
   - `"1"` — pokerus state.
@@ -175,7 +175,7 @@ re-loads — handy if a save you just wrote causes the game to misbehave.
 
 | tab | what you can change |
 |---|---|
-| **Currencies & Multipliers** | PokéDollars, Dungeon Tokens, Quest Points, Diamonds, Farm Points, plus four price multipliers from `player._itemMultipliers`: **Protein**, **Calcium**, **Carbos** (`<vitamin>\|money`) and **Master Ball** (`Masterball\|farmPoint`). Each row has a *Reset to 1.0* button; **Reset all vitamins to 1.0** zeros the three vitamins in one click. Rows left at exactly 1.0 are dropped from the save instead of being written, so the editor never adds spurious keys for shop items the user has never bought. |
+| **Currencies & Multipliers** | PokéDollars, Quest Points, Dungeon Tokens, Diamonds, Farm Points, Battle Points, Contest Tokens, plus four price multipliers from `player._itemMultipliers`: **Protein**, **Calcium**, **Carbos** (`<vitamin>\|money`) and **Master Ball** (`Masterball\|farmPoint`). Each row has a *Reset to 1.0* button; **Reset all vitamins to 1.0** zeros the three vitamins in one click. Rows left at exactly 1.0 are dropped from the save instead of being written, so the editor never adds spurious keys for shop items the user has never bought. |
 | **Eggs** | The breeding `eggList` (one row per slot). *Edit selected* opens a form. *Hatch now* sets `steps = totalSteps`. *Make empty* clears a slot back to `{type: -1, pokemon: 0}`. *Add egg* / *Remove* manage entries. **Quick-add** buttons drop a Grass / Fire / Water / Dragon / Mystery egg into the first empty slot (or append, bumping `eggSlots`). The `eggSlots` field above the table controls how many slots the game shows. |
 | **Shards** | Counts for the 16 type-shard colors (Red/Yellow/Green/Blue, Black/Grey, Purple/Crimson, Pink/White, Cyan/Lime, Rose/Ochre, Beige/Indigo). Editing a color you haven't unlocked yet is fine — it appears once you reach the right region. Buttons set the whole grid to 999 / 9999 / 0 in one click. Any unrecognised `*_shard` items in the save show up in the "Other" panel below the grid. |
 | **Berries** | All 70 BerryType entries from the v0.10.25 enum, sortable by index / name / count / unlocked state. Multi-select rows and use *Edit count…*, *Unlock selected*, or *Lock selected* for targeted edits; bulk buttons fill the whole roster (*Unlock/Lock all*, *Zero counts*, *All counts to 999 / 9999*). The *Show unlocked only* filter hides locked rows during edits. Below: the 7-slot `mulchList` (labelled from the `MulchType` enum, with the extra slot flagged as *Slot 6*) and the two shovel scalars (`shovelAmt`, `mulchShovelAmt`). `plotList`, `mutations`, and `farmHands` are not exposed — those are live mid-game state best touched in the game itself. |
@@ -213,9 +213,12 @@ Reference:
 | `get <save> <path>` | Read any field by [path](#path-syntax). |
 | `set <save> <path> <value> [-o out]` | Write any field. Value parsed as JSON literal first, then scalar. |
 | `money <save> <amount> [--add]` | Set/add PokéDollars (`currencies[0]`). |
-| `tokens <save> <amount> [--add]` | Set/add Dungeon Tokens (`currencies[1]`). |
-| `quest-points <save> <amount> [--add]` | Set/add Quest Points (`currencies[2]`). |
+| `quest-points <save> <amount> [--add]` | Set/add Quest Points (`currencies[1]`). |
+| `tokens <save> <amount> [--add]` | Set/add Dungeon Tokens (`currencies[2]`). |
+| `diamonds <save> <amount> [--add]` | Set/add Diamonds (`currencies[3]`). |
 | `farm-points <save> <amount> [--add]` | Set/add Farm Points (`currencies[4]`). |
+| `battle-points <save> <amount> [--add]` | Set/add Battle Points (`currencies[5]`). |
+| `contest-tokens <save> <amount> [--add]` | Set/add Contest Tokens (`currencies[6]`). |
 | `give <save> <item> <amount> [--set]` | Add (or `--set`) an inventory item count in `player._itemList`. |
 | `keyitem <save> <name> [--off]` | Toggle a key item under `save.keyItems`. |
 | `berry <save> <index> [--off]` | Unlock/lock a berry by index. |
@@ -234,13 +237,13 @@ python3 pcedit.py get     save.txt save.statistics.totalMoney
 python3 pcedit.py get     save.txt 'save.party.caughtPokemon[id=25]'
 
 # Currencies
-python3 pcedit.py money        save.txt 9999999
-python3 pcedit.py tokens       save.txt 1000000 --add
-python3 pcedit.py quest-points save.txt 50000
-python3 pcedit.py farm-points  save.txt 10000
-
-# Diamonds (no shortcut — use raw set)
-python3 pcedit.py set save.txt 'save.wallet.currencies[3]' 500
+python3 pcedit.py money          save.txt 9999999
+python3 pcedit.py quest-points   save.txt 50000
+python3 pcedit.py tokens         save.txt 1000000 --add
+python3 pcedit.py diamonds       save.txt 500
+python3 pcedit.py farm-points    save.txt 10000
+python3 pcedit.py battle-points  save.txt 1000
+python3 pcedit.py contest-tokens save.txt 200
 
 # Protein price multiplier
 python3 pcedit.py set save.txt 'player._itemMultipliers.Protein|money' 1.0

--- a/pcedit.py
+++ b/pcedit.py
@@ -31,7 +31,20 @@ REGIONS = [
 ]
 
 # Indices into the player's wallet currencies array. Stable across saves.
-CURRENCY = {"money": 0, "tokens": 1, "quest": 2, "diamonds": 3, "farm": 4, "battle": 5}
+# Matches PokeClicker's `enum Currency` in src/modules/GameConstants.ts:
+#   0 money, 1 questPoint, 2 dungeonToken, 3 diamond, 4 farmPoint,
+#   5 battlePoint, 6 contestToken.
+# (PCEdit had indices 1 and 2 swapped before v0.9.0 — "tokens" mapped to
+#  index 1 and "quest" to index 2 — see the Fixed entry in CHANGELOG.)
+CURRENCY = {
+    "money":    0,
+    "quest":    1,
+    "tokens":   2,
+    "diamonds": 3,
+    "farm":     4,
+    "battle":   5,
+    "contest":  6,
+}
 
 
 # --- IO helpers --------------------------------------------------------------
@@ -101,9 +114,12 @@ def cmd_summary(args: argparse.Namespace) -> int:
     print(f"pokémon:       {len(party)} caught, {sum(1 for x in party if isinstance(x, dict) and x.get('shiny'))} shiny in party")
     print(f"play time:     {_fmt_seconds(stats.get('secondsPlayed', 0))}")
     print(f"money:         {currencies[0] if len(currencies)>0 else '-'}")
-    print(f"dungeon tok:   {currencies[1] if len(currencies)>1 else '-'}")
-    print(f"quest pts:     {currencies[2] if len(currencies)>2 else '-'}")
+    print(f"quest pts:     {currencies[1] if len(currencies)>1 else '-'}")
+    print(f"dungeon tok:   {currencies[2] if len(currencies)>2 else '-'}")
+    print(f"diamonds:      {currencies[3] if len(currencies)>3 else '-'}")
     print(f"farm pts:      {currencies[4] if len(currencies)>4 else '-'}")
+    print(f"battle pts:    {currencies[5] if len(currencies)>5 else '-'}")
+    print(f"contest tok:   {currencies[6] if len(currencies)>6 else '-'}")
     print(f"quests done:   {stats.get('questsCompleted', 0)}  (xp {s.get('quests',{}).get('xp')})")
     print(f"hatched:       {stats.get('totalPokemonHatched', 0)}")
     print(f"shinies caught:{stats.get('totalShinyPokemonCaptured', 0)}")
@@ -151,6 +167,18 @@ def cmd_quest_pts(args: argparse.Namespace) -> int:
 
 def cmd_farm_pts(args: argparse.Namespace) -> int:
     return _set_currency(args, CURRENCY["farm"])
+
+
+def cmd_diamonds(args: argparse.Namespace) -> int:
+    return _set_currency(args, CURRENCY["diamonds"])
+
+
+def cmd_battle_pts(args: argparse.Namespace) -> int:
+    return _set_currency(args, CURRENCY["battle"])
+
+
+def cmd_contest_tokens(args: argparse.Namespace) -> int:
+    return _set_currency(args, CURRENCY["contest"])
 
 
 def _set_currency(args: argparse.Namespace, idx: int) -> int:
@@ -302,6 +330,9 @@ def main(argv: list[str] | None = None) -> int:
         ("tokens", cmd_tokens),
         ("quest-points", cmd_quest_pts),
         ("farm-points", cmd_farm_pts),
+        ("diamonds", cmd_diamonds),
+        ("battle-points", cmd_battle_pts),
+        ("contest-tokens", cmd_contest_tokens),
     ]:
         p = sub.add_parser(name, help=f"set/add {name.replace('-',' ')}")
         p.add_argument("input")

--- a/pcedit_gui.py
+++ b/pcedit_gui.py
@@ -2,8 +2,9 @@
 """pcedit_gui — Tkinter GUI for editing PokeClicker saves.
 
 Tabs:
-- Currencies & Multipliers: PokéDollars, dungeon tokens, quest points,
-  diamonds, farm points, plus the Protein price multiplier.
+- Currencies & Multipliers: PokéDollars, quest points, dungeon tokens,
+  diamonds, farm points, battle points, contest tokens, plus the
+  Protein price multiplier.
 - Eggs: edit/add/remove the 4-slot breeding egg list.
 - Caught Pokémon: scrollable table; double-click a row to edit.
 
@@ -48,14 +49,17 @@ from pcedit_updates import (
 )
 
 
-# Index → label for save.wallet.currencies. Position 5 is BattlePoints in some
-# versions; we leave it untouched.
+# Index → label for save.wallet.currencies. Matches PokeClicker's
+# `enum Currency` (see CURRENCY in pcedit.py for the canonical mapping
+# and the Fixed entry in CHANGELOG for the historical swap fix).
 CURRENCY_LABELS = [
-    ("PokéDollars",   0),
-    ("Dungeon Tokens", 1),
-    ("Quest Points",   2),
-    ("Diamonds",       3),
-    ("Farm Points",    4),
+    ("PokéDollars",     0),
+    ("Quest Points",    1),
+    ("Dungeon Tokens",  2),
+    ("Diamonds",        3),
+    ("Farm Points",     4),
+    ("Battle Points",   5),
+    ("Contest Tokens",  6),
 ]
 
 # Multipliers in player._itemMultipliers we expose as named rows.

--- a/web/src/lib/currencies.ts
+++ b/web/src/lib/currencies.ts
@@ -1,32 +1,43 @@
 /**
  * Read/write helpers for the Currencies & Multipliers tab.
  *
- * Mirrors `pcedit_gui.CurrenciesTab` (read on load, write on save) so the
- * Python and browser editors keep the same semantics — particularly:
+ * Mirrors `pcedit_gui.CurrenciesTab` and matches PokeClicker's
+ * `enum Currency` in `src/modules/GameConstants.ts`:
  *
- *   - Wallet positions are positional (`currencies[0]` = money,
- *     `[1]` = dungeon tokens, `[2]` = quest points, `[3]` = diamonds,
- *     `[4]` = farm points). Untouched higher slots stay intact.
- *   - Multipliers at exactly 1.0 are **dropped** from
- *     `player._itemMultipliers` rather than written, so we never add
- *     spurious entries for shop items the user has never bought.
+ *   0 money, 1 questPoint, 2 dungeonToken, 3 diamond, 4 farmPoint,
+ *   5 battlePoint, 6 contestToken.
  *
- * All functions are pure on the input shape — easy to unit-test without
- * touching the DOM or the file picker.
+ * (PCEdit had `tokens` and `quest` slugs pointing at the wrong indices
+ * before v0.9.0 — see the Fixed entry in CHANGELOG. The slug names
+ * stayed the same so CLI invocations like `pcedit tokens` keep working,
+ * but they now write the right slot.)
+ *
+ * Multipliers at exactly 1.0 are **dropped** from `player._itemMultipliers`
+ * rather than written, so we never add spurious entries for shop items
+ * the user has never bought.
  */
 import type { SaveData } from './save'
 
 // --- wallet -----------------------------------------------------------------
 
-export type CurrencyKey = 'money' | 'tokens' | 'quest' | 'diamonds' | 'farm'
+export type CurrencyKey =
+  | 'money'
+  | 'quest'
+  | 'tokens'
+  | 'diamonds'
+  | 'farm'
+  | 'battle'
+  | 'contest'
 
 /** Positional indices into `save.wallet.currencies`. Stable across saves. */
 export const CURRENCY_INDEX: Record<CurrencyKey, number> = {
-  money: 0,
-  tokens: 1,
-  quest: 2,
+  money:    0,
+  quest:    1,
+  tokens:   2,
   diamonds: 3,
-  farm: 4,
+  farm:     4,
+  battle:   5,
+  contest:  6,
 }
 
 export type Currencies = Record<CurrencyKey, number>
@@ -44,11 +55,13 @@ function getWallet(data: SaveData): number[] {
 export function readCurrencies(data: SaveData): Currencies {
   const arr = getWallet(data)
   return {
-    money: arr[CURRENCY_INDEX.money] ?? 0,
-    tokens: arr[CURRENCY_INDEX.tokens] ?? 0,
-    quest: arr[CURRENCY_INDEX.quest] ?? 0,
+    money:    arr[CURRENCY_INDEX.money] ?? 0,
+    quest:    arr[CURRENCY_INDEX.quest] ?? 0,
+    tokens:   arr[CURRENCY_INDEX.tokens] ?? 0,
     diamonds: arr[CURRENCY_INDEX.diamonds] ?? 0,
-    farm: arr[CURRENCY_INDEX.farm] ?? 0,
+    farm:     arr[CURRENCY_INDEX.farm] ?? 0,
+    battle:   arr[CURRENCY_INDEX.battle] ?? 0,
+    contest:  arr[CURRENCY_INDEX.contest] ?? 0,
   }
 }
 
@@ -64,6 +77,7 @@ export function writeCurrencies(data: SaveData, edits: Currencies): void {
     if (!Number.isInteger(v) || v < 0) {
       throw new RangeError(`${k}: expected non-negative integer, got ${v}`)
     }
+    while (arr.length <= idx) arr.push(0)   // pad short wallets up to contest (6)
     arr[idx] = v
   }
 }

--- a/web/src/tabs/CurrenciesTab.svelte
+++ b/web/src/tabs/CurrenciesTab.svelte
@@ -25,7 +25,7 @@
   // user loads a new save (store.data identity changes).
   let currencies = $derived.by<Currencies>(() => {
     if (!store.data) {
-      return { money: 0, tokens: 0, quest: 0, diamonds: 0, farm: 0 }
+      return { money: 0, quest: 0, tokens: 0, diamonds: 0, farm: 0, battle: 0, contest: 0 }
     }
     return readCurrencies(store.data)
   })
@@ -81,12 +81,16 @@
     store.markDirty()
   }
 
+  // Row order matches PokeClicker's `enum Currency` (and the desktop
+  // CURRENCY_LABELS in pcedit_gui.py), not the legacy PCEdit swap.
   const CURRENCY_ROWS: Array<{ key: CurrencyKey; label: string }> = [
-    { key: 'money', label: 'PokéDollars' },
-    { key: 'tokens', label: 'Dungeon Tokens' },
-    { key: 'quest', label: 'Quest Points' },
+    { key: 'money',    label: 'PokéDollars' },
+    { key: 'quest',    label: 'Quest Points' },
+    { key: 'tokens',   label: 'Dungeon Tokens' },
     { key: 'diamonds', label: 'Diamonds' },
-    { key: 'farm', label: 'Farm Points' },
+    { key: 'farm',     label: 'Farm Points' },
+    { key: 'battle',   label: 'Battle Points' },
+    { key: 'contest',  label: 'Contest Tokens' },
   ]
 </script>
 

--- a/web/tests/currencies.spec.ts
+++ b/web/tests/currencies.spec.ts
@@ -32,66 +32,63 @@ const loadFixture = () => decodeBytes(readFileSync(FIXTURE, 'utf8').trim())
 describe('currencies', () => {
   test('readCurrencies pulls positional values from save.wallet.currencies', () => {
     const data = loadFixture()
+    // Fixture array is [10000, 1000, 100, 10, 50, 0, 0] — canonical order:
+    // money / questPoint / dungeonToken / diamond / farmPoint / battlePoint
+    // / contestToken.
     expect(readCurrencies(data)).toEqual({
-      money: 10000,
-      tokens: 1000,
-      quest: 100,
+      money:    10000,
+      quest:    1000,
+      tokens:   100,
       diamonds: 10,
-      farm: 50,
+      farm:     50,
+      battle:   0,
+      contest:  0,
     })
   })
 
   test('writeCurrencies round-trips through readCurrencies', () => {
     const data = loadFixture()
     writeCurrencies(data, {
-      money: 9999999,
-      tokens: 500000,
-      quest: 250000,
+      money:    9999999,
+      quest:    250000,
+      tokens:   500000,
       diamonds: 2500,
-      farm: 75000,
+      farm:     75000,
+      battle:   1234,
+      contest:  567,
     })
     expect(readCurrencies(data)).toEqual({
-      money: 9999999,
-      tokens: 500000,
-      quest: 250000,
+      money:    9999999,
+      quest:    250000,
+      tokens:   500000,
       diamonds: 2500,
-      farm: 75000,
+      farm:     75000,
+      battle:   1234,
+      contest:  567,
     })
   })
 
-  test('writeCurrencies preserves higher slots (battle points, etc.)', () => {
+  test('writeCurrencies pads short wallets up to the contest-token slot', () => {
     const data = loadFixture()
-    const before = ((data.save as any).wallet.currencies as number[])[5]
+    // Truncate the fixture wallet to simulate an older save without BP/contest.
+    ;(data.save as any).wallet.currencies = [10000, 1000, 100, 10, 50]
     writeCurrencies(data, {
-      money: 1,
-      tokens: 2,
-      quest: 3,
-      diamonds: 4,
-      farm: 5,
+      money: 1, quest: 2, tokens: 3, diamonds: 4, farm: 5, battle: 6, contest: 7,
     })
-    expect(((data.save as any).wallet.currencies as number[])[5]).toBe(before)
+    const arr = (data.save as any).wallet.currencies as number[]
+    expect(arr).toHaveLength(7)
+    expect(arr).toEqual([1, 2, 3, 4, 5, 6, 7])
   })
 
   test('writeCurrencies rejects negative and non-integer inputs', () => {
     const data = loadFixture()
-    expect(() =>
-      writeCurrencies(data, {
-        money: -1,
-        tokens: 0,
-        quest: 0,
-        diamonds: 0,
-        farm: 0,
-      }),
-    ).toThrow(/non-negative integer/)
-    expect(() =>
-      writeCurrencies(data, {
-        money: 1.5,
-        tokens: 0,
-        quest: 0,
-        diamonds: 0,
-        farm: 0,
-      }),
-    ).toThrow(/non-negative integer/)
+    const zeroed = {
+      money: 0, quest: 0, tokens: 0, diamonds: 0, farm: 0, battle: 0, contest: 0,
+    }
+    expect(() => writeCurrencies(data, { ...zeroed, money: -1 })).toThrow(/non-negative integer/)
+    expect(() => writeCurrencies(data, { ...zeroed, money: 1.5 })).toThrow(/non-negative integer/)
+    expect(() => writeCurrencies(data, { ...zeroed, battle: -5 })).toThrow(/non-negative integer/)
+    expect(() => writeCurrencies(data, { ...zeroed, contest: 1.1 })).toThrow(/non-negative integer/)
   })
 })
 


### PR DESCRIPTION
## Summary

**Bug fix:** PCEdit's `CURRENCY` constant has mapped `tokens` to `currencies[1]` and `quest` to `currencies[2]` since v0.1, but PokeClicker's canonical [`enum Currency`](https://github.com/pokeclicker/pokeclicker/blob/develop/src/modules/GameConstants.ts) has `questPoint` at 1 and `dungeonToken` at 2. Both runtimes (desktop CLI/GUI and web SPA) consistently labeled them backwards. Live save spot-check: the user's 50M-value slot 1 was being labeled "Dungeon Tokens" when it's actually Quest Points (60M slot was labeled "Quest Points"). The data round-trips fine — only the labels and CLI subcommand routing were wrong.

**New surface:** Both runtimes now also expose `currencies[5]` (Battle Points, earned at the Battle Frontier) and `currencies[6]` (Contest Tokens, BattleCafe) — slots the editor previously left untouched. CLI gains three new subcommands: `battle-points`, `contest-tokens`, and `diamonds` (the last filling a long-standing gap — index 3 had no shortcut).

**Compatibility:** Slug names are unchanged, so `pcedit tokens 9999` / `pcedit quest-points 9999` keep working — they now write the right slot. `writeCurrencies` pads short wallets up to index 6 before writing, so saves predating these slots round-trip cleanly.

## What changed

| File | Change |
|---|---|
| `pcedit.py` | `CURRENCY` dict — swap `tokens`/`quest` mapping, add `contest`. Summary print — fix labels, add 3 new lines. Add `cmd_diamonds` / `cmd_battle_pts` / `cmd_contest_tokens` + argparse registration. |
| `pcedit_gui.py` | `CURRENCY_LABELS` — fix the swap, add 2 rows for BP/Contest. Update top docstring. |
| `web/src/lib/currencies.ts` | `CURRENCY_INDEX` — fix swap + add battle/contest. Pad-then-write in `writeCurrencies`. Update doc comment. |
| `web/src/tabs/CurrenciesTab.svelte` | `CURRENCY_ROWS` — fix order, add 2 new rows. Update empty-state shape. |
| `web/tests/currencies.spec.ts` | Fixture expectations now cover all 7 slots; round-trip and reject tests extended; new pad-and-write test. |
| `CHANGELOG.md` | `### Fixed` entry for the swap, extended `### Added` entry for the new currencies. |
| `README.md` | Positional array doc, tab descriptions, CLI table, examples. |

## Test plan

- [x] `npm run check` (web): 0 errors, 0 warnings
- [x] `npm run test` (web): 109/109 pass
- [x] `npm run build` (web): 36.94 KB gzipped
- [x] `python3 -m unittest discover tests`: 33/33 pass
- [x] `python3 pcedit.py summary` on real save — quest pts now 50M (canonical), dungeon tok now 60M (canonical), new battle/contest/diamonds lines render
- [x] `python3 pcedit.py --help` lists the 3 new subcommands
- [ ] Manual: load real save in browser dev server, confirm 7 rows show correct values, edit BP, save, reload, confirm round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)