### PR TITLE
Fix Caught tab pokérus/shiny save-key mapping (web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Release notes.
 ## [Unreleased]
 
 ### Fixed
+- **Caught Pokémon: pokérus and shiny read the wrong save keys (web).**
+  The Caught tab read pokérus from key `"1"` (which is actually
+  `attackBonusAmount`), so the column showed large numbers instead of the
+  Pokérus state. Pokérus lives at key `"8"` (the canonical
+  `PartyPokemonSaveKeys` enum). The "resistant" column/flag was reading and
+  writing key `"5"`, which is actually the **shiny** flag — so "Mark
+  resistant" silently toggled shiny. Pokérus now reads/writes key `"8"` and
+  is edited via a named dropdown (0 Uninfected / 1 Infected / 2 Contagious /
+  3 Resistant); the column is relabeled **Shiny** to reflect what key `"5"`
+  really is. Desktop is unchanged (being discontinued).
 - **Wallet currency indices 1 and 2 were swapped vs canonical PokeClicker.**
   PCEdit's `CURRENCY` constant historically mapped the slug `tokens`
   to index 1 and `quest` to index 2, but PokeClicker's

--- a/web/src/lib/caught.ts
+++ b/web/src/lib/caught.ts
@@ -1,27 +1,32 @@
 /**
- * Read/write helpers for the Caught Pokémon tab — port of
- * pcedit_gui.CaughtTab and CaughtDialog.
+ * Read/write helpers for the Caught Pokémon tab.
  *
- * Save shape (under `save.party.caughtPokemon`):
+ * Save shape (under `save.party.caughtPokemon`). Numeric keys are the
+ * canonical PokeClicker `PartyPokemonSaveKeys` enum — only the ones the
+ * editor touches are listed; the rest are preserved untouched:
  *
  *   [
  *     {
  *       id:  pokédex id (int),
- *       "0": attack bonus from hatching (25 = first hatch tier),
- *       "1": pokerus state (0..4),
- *       "2": EVs by attack type (dict; the editor does not touch this),
- *       "3": total exp,
- *       "4": (optional bool) currently in egg / breeding-pending,
- *       "5": (optional bool) resistant flag,
+ *       "0": attackBonusPercent — hatch bonus (25 = first hatch tier),
+ *       "1": attackBonusAmount  — flat attack bonus (NOT edited; preserved),
+ *       "2": vitaminsUsed       — dict (NOT edited; preserved),
+ *       "3": exp                — total exp,
+ *       "4": (optional bool) breeding — currently in the hatchery/egg,
+ *       "5": (optional bool) shiny,
+ *       "8": pokerus state — Pokerus enum 0..3
+ *            (0 Uninfected, 1 Infected, 2 Contagious, 3 Resistant),
  *     },
  *     ...
  *   ]
  *
- * The desktop tab preserves the "key absent" vs "value false" distinction
- * for the `4` and `5` flags: setting either to false **removes** the key.
- * That matches what real saves look like (the game writes the keys only
- * when the flags are true) and keeps round-trips clean. We mirror that
- * here.
+ * Pokerus lives at key "8" — earlier versions of this editor read it from
+ * "1" (attackBonusAmount), which surfaced large numbers as "pokerus".
+ *
+ * The "4" (breeding/in-egg) and "5" (shiny) flags follow the "key absent"
+ * vs "value false" distinction: setting either to false **removes** the
+ * key. That matches what real saves look like (the game writes the keys
+ * only when true) and keeps byte-identical round-trips clean.
  */
 import { nameFor } from './data'
 import type { SaveData } from './save'
@@ -31,11 +36,11 @@ import type { SaveData } from './save'
 export type CaughtRow = {
   id: number
   name: string
-  atkBonus: number   // "0"
-  pokerus: number    // "1"
-  exp: number        // "3"
-  inEgg: boolean     // "4" — true iff key present and truthy
-  resistant: boolean // "5" — true iff key present and truthy
+  atkBonus: number // "0"
+  pokerus: number  // "8" — Pokerus enum 0..3
+  exp: number      // "3"
+  inEgg: boolean   // "4" (breeding) — true iff key present and truthy
+  shiny: boolean   // "5" — true iff key present and truthy
 }
 
 /** Patch shape applied by the edit dialog. Optional fields are skipped. */
@@ -44,7 +49,7 @@ export type CaughtPatch = {
   pokerus?: number
   exp?: number
   inEgg?: boolean
-  resistant?: boolean
+  shiny?: boolean
 }
 
 // --- accessors --------------------------------------------------------------
@@ -87,6 +92,13 @@ function ensureNonNegInt(name: string, v: number): void {
   }
 }
 
+/** Pokerus is the PokeClicker Pokerus enum: 0..3. */
+function ensurePokerus(v: number): void {
+  if (!Number.isInteger(v) || v < 0 || v > 3) {
+    throw new RangeError(`pokerus: expected integer 0..3 (Uninfected..Resistant), got ${v}`)
+  }
+}
+
 // --- public reads -----------------------------------------------------------
 
 export function readCaughtRows(data: SaveData): CaughtRow[] {
@@ -99,10 +111,10 @@ export function readCaughtRows(data: SaveData): CaughtRow[] {
       id,
       name: nameFor(id),
       atkBonus: asInt(entry['0']),
-      pokerus: asInt(entry['1']),
+      pokerus: asInt(entry['8']),
       exp: asInt(entry['3']),
       inEgg: Boolean(entry['4']),
-      resistant: Boolean(entry['5']),
+      shiny: Boolean(entry['5']),
     })
   }
   return out
@@ -126,8 +138,8 @@ export function setCaughtEntry(
     entry['0'] = patch.atkBonus
   }
   if (patch.pokerus !== undefined) {
-    ensureNonNegInt('pokerus', patch.pokerus)
-    entry['1'] = patch.pokerus
+    ensurePokerus(patch.pokerus)
+    entry['8'] = patch.pokerus
   }
   if (patch.exp !== undefined) {
     ensureNonNegInt('exp', patch.exp)
@@ -137,14 +149,14 @@ export function setCaughtEntry(
     if (patch.inEgg) entry['4'] = true
     else delete entry['4']
   }
-  if (patch.resistant !== undefined) {
-    if (patch.resistant) entry['5'] = true
+  if (patch.shiny !== undefined) {
+    if (patch.shiny) entry['5'] = true
     else delete entry['5']
   }
 }
 
-/** Bulk: set `resistant` on multiple ids. Off → delete the key (no `false`). */
-export function setCaughtResistant(
+/** Bulk: set `shiny` (key "5") on multiple ids. Off → delete the key (no `false`). */
+export function setCaughtShiny(
   data: SaveData,
   ids: number[],
   on: boolean,

--- a/web/src/tabs/CaughtTab.svelte
+++ b/web/src/tabs/CaughtTab.svelte
@@ -10,23 +10,27 @@
     readCaughtRows,
     setCaughtAtkBonus,
     setCaughtEntry,
-    setCaughtResistant,
+    setCaughtShiny,
     type CaughtPatch,
     type CaughtRow,
   } from '../lib/caught'
   import NumberField from '../components/NumberField.svelte'
+
+  // PokeClicker Pokerus enum (key "8"): 0 Uninfected … 3 Resistant.
+  const POKERUS_LABELS = ['Uninfected', 'Infected', 'Contagious', 'Resistant'] as const
+  const pokerusLabel = (n: number): string => POKERUS_LABELS[n] ?? String(n)
 
   // --- reactive state ----------------------------------------------------
 
   let tick = $state(0)
   let selectedId = $state<number | null>(null)
 
-  type SortCol = 'id' | 'name' | 'atkBonus' | 'pokerus' | 'exp' | 'inEgg' | 'resistant'
+  type SortCol = 'id' | 'name' | 'atkBonus' | 'pokerus' | 'exp' | 'inEgg' | 'shiny'
   let sortCol = $state<SortCol>('id')
   let sortReverse = $state(false)
 
   const NUMERIC_COLS: ReadonlySet<SortCol> = new Set(['id', 'atkBonus', 'pokerus', 'exp'])
-  const BOOL_COLS: ReadonlySet<SortCol> = new Set(['inEgg', 'resistant'])
+  const BOOL_COLS: ReadonlySet<SortCol> = new Set(['inEgg', 'shiny'])
 
   let rows = $derived.by<CaughtRow[]>(() => {
     void tick
@@ -92,15 +96,15 @@
 
   // --- quick actions -----------------------------------------------------
 
-  function onMarkResistant(): void {
+  function onMarkShiny(): void {
     if (selectedId === null) return
     const id = selectedId
-    refreshAfter(() => setCaughtResistant(store.data!, [id], true))
+    refreshAfter(() => setCaughtShiny(store.data!, [id], true))
   }
-  function onClearResistant(): void {
+  function onClearShiny(): void {
     if (selectedId === null) return
     const id = selectedId
-    refreshAfter(() => setCaughtResistant(store.data!, [id], false))
+    refreshAfter(() => setCaughtShiny(store.data!, [id], false))
   }
   function onAtkBonus100(): void {
     if (selectedId === null) return
@@ -120,7 +124,7 @@
       pokerus: selectedRow.pokerus,
       exp: selectedRow.exp,
       inEgg: selectedRow.inEgg,
-      resistant: selectedRow.resistant,
+      shiny: selectedRow.shiny,
     }
     dialogEl?.showModal()
   }
@@ -164,7 +168,7 @@
             <th><button type="button" onclick={() => toggleSort('pokerus')}>pokerus{sortIndicator('pokerus')}</button></th>
             <th><button type="button" onclick={() => toggleSort('exp')}>exp{sortIndicator('exp')}</button></th>
             <th><button type="button" onclick={() => toggleSort('inEgg')}>in egg{sortIndicator('inEgg')}</button></th>
-            <th><button type="button" onclick={() => toggleSort('resistant')}>resistant{sortIndicator('resistant')}</button></th>
+            <th><button type="button" onclick={() => toggleSort('shiny')}>shiny{sortIndicator('shiny')}</button></th>
           </tr>
         </thead>
         <tbody>
@@ -177,10 +181,10 @@
               <td>{row.id}</td>
               <td class="name-col">{row.name}</td>
               <td>{row.atkBonus}</td>
-              <td>{row.pokerus}</td>
+              <td>{pokerusLabel(row.pokerus)}</td>
               <td>{row.exp}</td>
               <td>{row.inEgg ? 'yes' : ''}</td>
-              <td>{row.resistant ? 'yes' : ''}</td>
+              <td>{row.shiny ? 'yes' : ''}</td>
             </tr>
           {:else}
             <tr><td colspan="7" class="muted">(no caught pokémon)</td></tr>
@@ -193,11 +197,11 @@
       <button type="button" onclick={openEdit} disabled={selectedRow === null}>
         Edit selected…
       </button>
-      <button type="button" onclick={onMarkResistant} disabled={selectedRow === null}>
-        Mark resistant
+      <button type="button" onclick={onMarkShiny} disabled={selectedRow === null}>
+        Mark shiny
       </button>
-      <button type="button" onclick={onClearResistant} disabled={selectedRow === null}>
-        Clear resistant
+      <button type="button" onclick={onClearShiny} disabled={selectedRow === null}>
+        Clear shiny
       </button>
       <button type="button" onclick={onAtkBonus100} disabled={selectedRow === null}>
         Set atkBonus 100
@@ -217,12 +221,17 @@
         onCommit={(n) => (draft.atkBonus = n)}
         labelWidth="11rem"
       />
-      <NumberField
-        label="pokerus (0=none, 1–4)"
-        value={draft.pokerus ?? 0}
-        onCommit={(n) => (draft.pokerus = n)}
-        labelWidth="11rem"
-      />
+      <label class="row select-row">
+        <span class="select-label">pokerus</span>
+        <select
+          value={String(draft.pokerus ?? 0)}
+          onchange={(e) => (draft.pokerus = Number((e.target as HTMLSelectElement).value))}
+        >
+          {#each POKERUS_LABELS as label, value (value)}
+            <option value={String(value)}>{value} — {label}</option>
+          {/each}
+        </select>
+      </label>
       <NumberField
         label="exp"
         value={draft.exp ?? 0}
@@ -241,10 +250,10 @@
       <label class="row checkbox">
         <input
           type="checkbox"
-          checked={draft.resistant ?? false}
-          onchange={(e) => (draft.resistant = (e.target as HTMLInputElement).checked)}
+          checked={draft.shiny ?? false}
+          onchange={(e) => (draft.shiny = (e.target as HTMLInputElement).checked)}
         />
-        <span>resistant</span>
+        <span>shiny</span>
       </label>
 
       <div class="dialog-actions">
@@ -379,6 +388,21 @@
   }
   .row.checkbox {
     margin-top: 0.25rem;
+  }
+  .select-row {
+    gap: 0.75rem;
+  }
+  .select-label {
+    width: 11rem;
+    flex: none;
+  }
+  .select-row select {
+    flex: 1;
+    padding: 0.3rem 0.4rem;
+    font: inherit;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: white;
   }
   .dialog-actions {
     display: flex;

--- a/web/tests/caught.spec.ts
+++ b/web/tests/caught.spec.ts
@@ -1,9 +1,14 @@
 /**
  * Pure-function tests for the caught-pokémon helpers.
  *
- * Particular focus on the key-present-iff-true rule for inEgg/resistant —
- * a regression here would break byte-identity round-trips against real
- * saves that have never had those flags set.
+ * Key mapping is the canonical PokeClicker PartyPokemonSaveKeys:
+ *   0 attackBonusPercent, 1 attackBonusAmount, 2 vitaminsUsed, 3 exp,
+ *   4 breeding, 5 shiny, 8 pokerus, 9 effortPoints.
+ *
+ * Particular focus on (a) pokerus living at key "8" (NOT "1"), (b) shiny at
+ * key "5", and (c) the key-present-iff-true rule for inEgg/shiny — a
+ * regression there would break byte-identity round-trips against real saves
+ * that have never had those flags set.
  */
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -15,7 +20,7 @@ import {
   setCaughtAtkBonus,
   setCaughtEntry,
   setCaughtInEgg,
-  setCaughtResistant,
+  setCaughtShiny,
 } from '../src/lib/caught'
 
 const FIXTURE = resolve(
@@ -48,9 +53,10 @@ describe('readCaughtRows', () => {
       expect(typeof r.name).toBe('string')
       expect(r.name.length).toBeGreaterThan(0)
       expect(typeof r.atkBonus).toBe('number')
+      expect(typeof r.pokerus).toBe('number')
       expect(typeof r.exp).toBe('number')
       expect(typeof r.inEgg).toBe('boolean')
-      expect(typeof r.resistant).toBe('boolean')
+      expect(typeof r.shiny).toBe('boolean')
     }
   })
 
@@ -61,16 +67,44 @@ describe('readCaughtRows', () => {
     expect(byId.get(4)?.name).toBe('Charmander')
     expect(byId.get(25)?.name).toBe('Pikachu')
   })
+
+  test('pokerus reads key "8" (state), never "1" (attackBonusAmount)', () => {
+    // Regression: the editor previously read pokerus from key "1", surfacing
+    // large attackBonusAmount values as "pokerus". Pokerus lives at key "8".
+    const data = loadFixture()
+    const e = rawEntry(data, 4)
+    e['1'] = 2046 // attackBonusAmount — a big number that must NOT be pokerus
+    e['8'] = 2 // real pokerus = Contagious
+    const row = readCaughtRows(data).find((r) => r.id === 4)!
+    expect(row.pokerus).toBe(2)
+  })
+
+  test('shiny reads key "5"', () => {
+    const data = loadFixture()
+    rawEntry(data, 25)['5'] = true
+    const row = readCaughtRows(data).find((r) => r.id === 25)!
+    expect(row.shiny).toBe(true)
+  })
 })
 
 describe('setCaughtEntry', () => {
-  test('numeric fields round-trip', () => {
+  test('numeric fields round-trip to canonical keys', () => {
     const data = loadFixture()
     setCaughtEntry(data, 4, { atkBonus: 100, pokerus: 3, exp: 1234567 })
+    expect(rawEntry(data, 4)['0']).toBe(100) // attackBonusPercent
+    expect(rawEntry(data, 4)['8']).toBe(3) // pokerus -> key "8", not "1"
+    expect(rawEntry(data, 4)['3']).toBe(1234567)
     const row = readCaughtRows(data).find((r) => r.id === 4)!
     expect(row.atkBonus).toBe(100)
     expect(row.pokerus).toBe(3)
     expect(row.exp).toBe(1234567)
+  })
+
+  test('pokerus rejects values outside 0..3', () => {
+    const data = loadFixture()
+    expect(() => setCaughtEntry(data, 4, { pokerus: 4 })).toThrow(/pokerus/)
+    expect(() => setCaughtEntry(data, 4, { pokerus: -1 })).toThrow(/pokerus/)
+    expect(() => setCaughtEntry(data, 4, { pokerus: 1.5 })).toThrow(/pokerus/)
   })
 
   test('inEgg=true sets the "4" key; inEgg=false deletes it', () => {
@@ -81,21 +115,21 @@ describe('setCaughtEntry', () => {
     expect('4' in rawEntry(data, 4)).toBe(false)
   })
 
-  test('resistant=true sets the "5" key; resistant=false deletes it', () => {
+  test('shiny=true sets the "5" key; shiny=false deletes it', () => {
     const data = loadFixture()
-    setCaughtEntry(data, 25, { resistant: true })
+    setCaughtEntry(data, 25, { shiny: true })
     expect(rawEntry(data, 25)['5']).toBe(true)
-    setCaughtEntry(data, 25, { resistant: false })
+    setCaughtEntry(data, 25, { shiny: false })
     expect('5' in rawEntry(data, 25)).toBe(false)
   })
 
-  test('preserves untouched fields and the EVs sub-dict', () => {
+  test('preserves untouched fields and the vitamins sub-dict', () => {
     const data = loadFixture()
     const before = { ...rawEntry(data, 4) }
     setCaughtEntry(data, 4, { atkBonus: 50 })
     const after = rawEntry(data, 4)
-    expect(after['1']).toBe(before['1']) // pokerus untouched
-    expect(after['2']).toEqual(before['2']) // EVs untouched
+    expect(after['1']).toBe(before['1']) // attackBonusAmount untouched
+    expect(after['2']).toEqual(before['2']) // vitamins untouched
     expect(after['3']).toBe(before['3']) // exp untouched
   })
 
@@ -112,12 +146,12 @@ describe('setCaughtEntry', () => {
 })
 
 describe('quick-action bulk helpers', () => {
-  test('setCaughtResistant true sets the key, false deletes it', () => {
+  test('setCaughtShiny true sets key "5", false deletes it', () => {
     const data = loadFixture()
-    setCaughtResistant(data, [4, 25], true)
+    setCaughtShiny(data, [4, 25], true)
     expect(rawEntry(data, 4)['5']).toBe(true)
     expect(rawEntry(data, 25)['5']).toBe(true)
-    setCaughtResistant(data, [4, 25], false)
+    setCaughtShiny(data, [4, 25], false)
     expect('5' in rawEntry(data, 4)).toBe(false)
     expect('5' in rawEntry(data, 25)).toBe(false)
   })


### PR DESCRIPTION
## Summary
The web **Caught Pokémon** tab read the wrong canonical `PartyPokemonSaveKeys`:
- **pokérus** was read from key `"1"` (`attackBonusAmount`) → showed large numbers instead of the 0–3 state. It actually lives at key **`"8"`**.
- the **"resistant"** column/flag read & wrote key `"5"`, which is really the **shiny** flag — so *"Mark resistant"* silently toggled shiny.

## Changes
- `caught.ts`: pokérus → key `"8"` (validated 0..3); `resistant` → `shiny` on key `"5"`; `setCaughtResistant` → `setCaughtShiny`; corrected the save-shape doc comment.
- `CaughtTab.svelte`: pokérus shown as a named state and edited via a dropdown (0 Uninfected / 1 Infected / 2 Contagious / 3 Resistant); "resistant" column + bulk buttons relabeled **Shiny**.
- `caught.spec.ts`: assert canonical keys; regression test that a large key-`"1"` value is *not* surfaced as pokérus.

Desktop (`pcedit_gui.py`) intentionally **left unchanged** — it's being discontinued.

## Test Plan
- [x] `npm run test` — 112 pass (caught suite 16, +3 incl. regression)
- [x] `npx svelte-check` — 0 errors
- [x] `npm run build` — clean
- [x] Verified against a real v0.10.25 save: Togekiss #468 (was "pokerus 2046") now reads **Uninfected**; #14/#16 correctly flagged **shiny**

🤖 Generated with [Claude Code](https://claude.com/claude-code)