### PR TITLE
Web: Pokédex tab (region-filtered mark-caught + optional stat bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Release notes.
 
 ## [Unreleased]
 
+### Added
+- **Web: Pokédex tab.** Ports the desktop Pokédex feature to the browser app —
+  pick a region, view its dex with caught marks (with a "show uncaught only"
+  filter), and mark uncaught pokémon caught (selected rows or the whole
+  region). Already-caught entries are left untouched. An optional "Also bump
+  capture stats" toggle (off by default) keeps the Trainer Card counters
+  (`totalPokemonCaptured`, `pokemonCaptured.<id>`, gender buckets, …)
+  consistent with the dex.
+
 ### Fixed
 - **Wallet currency indices 1 and 2 were swapped vs canonical PokeClicker.**
   PCEdit's `CURRENCY` constant historically mapped the slug `tokens`

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -11,6 +11,7 @@
   import CaughtTab from './tabs/CaughtTab.svelte'
   import GemsTab from './tabs/GemsTab.svelte'
   import FlutesTab from './tabs/FlutesTab.svelte'
+  import PokedexTab from './tabs/PokedexTab.svelte'
 
   const tabs: readonly Tab[] = [
     { id: 'currencies', label: 'Currencies & Multipliers' },
@@ -20,6 +21,7 @@
     { id: 'flutes', label: 'Flutes' },
     { id: 'berries', label: 'Berries' },
     { id: 'caught', label: 'Caught Pokémon' },
+    { id: 'pokedex', label: 'Pokédex' },
   ]
 
   let active = $state(tabs[0].id)
@@ -51,6 +53,8 @@
     <BerriesTab />
   {:else if active === 'caught'}
     <CaughtTab />
+  {:else if active === 'pokedex'}
+    <PokedexTab />
   {/if}
 
   <footer>

--- a/web/src/lib/pokedex.ts
+++ b/web/src/lib/pokedex.ts
@@ -1,0 +1,129 @@
+/**
+ * Pokédex mark-caught helpers — web port of pcedit_gui.PokedexTab.
+ *
+ * "Marking caught" appends a minimal entry to `save.party.caughtPokemon`:
+ *   { "2": { "0": 0, "1": 0, "2": 0 }, "3": 1, id: <pid> }
+ * i.e. zeroed vitamins (key "2"), exp (key "3") = 1, and the dex id. Entries
+ * that already exist are left untouched (re-marking is a no-op).
+ *
+ * The optional stat bump mirrors the desktop's `_bump_stats`: it keeps the
+ * Trainer Card counters consistent with the dex when the user opts in. It is
+ * off by default because it changes Trainer Card numbers (and, downstream,
+ * achievement progress).
+ */
+import { nameFor, statBucketFor } from './data'
+import type { RegionRange } from './data'
+import type { SaveData } from './save'
+
+/** Exp written into a freshly marked-caught entry (matches desktop default). */
+const NEW_ENTRY_EXP = 1
+
+export type DexRow = { pid: number; name: string; caught: boolean }
+
+export type MarkOptions = {
+  /** Also bump `save.statistics` capture counters. Default false. */
+  bumpStats?: boolean
+}
+
+// --- accessors --------------------------------------------------------------
+
+function caughtParty(data: SaveData): Array<Record<string, unknown>> {
+  const save = data.save as Record<string, unknown> | undefined
+  const party = save?.party as Record<string, unknown> | undefined
+  const list = party?.caughtPokemon as Array<Record<string, unknown>> | undefined
+  if (!Array.isArray(list)) {
+    throw new Error('save.party.caughtPokemon is missing or not an array')
+  }
+  return list
+}
+
+function asInt(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? Math.trunc(v) : 0
+}
+
+// --- reads ------------------------------------------------------------------
+
+/** Set of national-dex ids already present in the party. */
+export function caughtIdSet(data: SaveData): Set<number> {
+  const out = new Set<number>()
+  for (const e of caughtParty(data)) {
+    if (e && typeof e.id === 'number') out.add(e.id)
+  }
+  return out
+}
+
+/**
+ * Rows for a region's dex (one per id in `[lo, hi]`). With `uncaughtOnly`,
+ * already-caught ids are omitted.
+ */
+export function regionRows(
+  data: SaveData,
+  region: RegionRange,
+  uncaughtOnly = false,
+): DexRow[] {
+  const caught = caughtIdSet(data)
+  const rows: DexRow[] = []
+  for (let pid = region.lo; pid <= region.hi; pid++) {
+    const isCaught = caught.has(pid)
+    if (uncaughtOnly && isCaught) continue
+    rows.push({ pid, name: nameFor(pid), caught: isCaught })
+  }
+  return rows
+}
+
+// --- writes -----------------------------------------------------------------
+
+/**
+ * Append caught entries for any `ids` not already in the party. Returns the
+ * number of entries actually added. With `bumpStats`, also updates the
+ * `save.statistics` capture counters for the newly-added ids.
+ */
+export function markCaught(
+  data: SaveData,
+  ids: number[],
+  opts: MarkOptions = {},
+): number {
+  const party = caughtParty(data)
+  const existing = caughtIdSet(data)
+  const added: number[] = []
+  for (const pid of ids) {
+    if (existing.has(pid)) continue
+    party.push({ '2': { '0': 0, '1': 0, '2': 0 }, '3': NEW_ENTRY_EXP, id: pid })
+    existing.add(pid)
+    added.push(pid)
+  }
+  if (added.length && opts.bumpStats) bumpCaptureStats(data, added)
+  return added.length
+}
+
+/**
+ * Update `save.statistics` so the Trainer Card matches the dex, for each
+ * newly-marked id:
+ *   - `pokemonCaptured[id]` / `pokemonEncountered[id]` set to `max(1, current)`
+ *   - the species' gender bucket (Male/Female/Genderless) +1 for both the
+ *     Captured and Encountered buckets (ids outside the table credit only the
+ *     gender-neutral total)
+ *   - `totalPokemonCaptured` / `totalPokemonEncountered` += `ids.length`
+ */
+function bumpCaptureStats(data: SaveData, ids: number[]): void {
+  const save = data.save as Record<string, unknown>
+  const stats = (save.statistics ??= {}) as Record<string, unknown>
+  const captured = (stats.pokemonCaptured ??= {}) as Record<string, number>
+  const encountered = (stats.pokemonEncountered ??= {}) as Record<string, number>
+
+  for (const pid of ids) {
+    const key = String(pid)
+    captured[key] = Math.max(1, asInt(captured[key]))
+    encountered[key] = Math.max(1, asInt(encountered[key]))
+
+    const capBucket = statBucketFor(pid)
+    if (capBucket) {
+      const encBucket = capBucket.replace('Captured', 'Encountered')
+      stats[capBucket] = asInt(stats[capBucket]) + 1
+      stats[encBucket] = asInt(stats[encBucket]) + 1
+    }
+  }
+
+  stats.totalPokemonCaptured = asInt(stats.totalPokemonCaptured) + ids.length
+  stats.totalPokemonEncountered = asInt(stats.totalPokemonEncountered) + ids.length
+}

--- a/web/src/tabs/PokedexTab.svelte
+++ b/web/src/tabs/PokedexTab.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+  // Pokédex tab — web port of pcedit_gui.PokedexTab.
+  //
+  // Pick a region, see its dex with caught marks, and mark uncaught pokémon
+  // caught (selected rows, or the whole region). Already-caught entries are
+  // left untouched. The "Also bump capture stats" toggle (off by default)
+  // keeps the Trainer Card counters consistent.
+
+  import { store } from '../lib/store.svelte'
+  import { REGION_RANGES } from '../lib/data'
+  import { markCaught, regionRows, type DexRow } from '../lib/pokedex'
+
+  let tick = $state(0)
+  let regionLabel = $state(REGION_RANGES[0].label)
+  let uncaughtOnly = $state(false)
+  let bumpStats = $state(false)
+  let selected = $state<Set<number>>(new Set())
+
+  let region = $derived(
+    REGION_RANGES.find((r) => r.label === regionLabel) ?? REGION_RANGES[0],
+  )
+
+  let rows = $derived.by<DexRow[]>(() => {
+    void tick
+    return store.data ? regionRows(store.data, region, uncaughtOnly) : []
+  })
+
+  let caughtInRegion = $derived(rows.filter((r) => r.caught).length)
+  let regionTotal = $derived(region.hi - region.lo + 1)
+
+  function toggle(pid: number): void {
+    const next = new Set(selected)
+    if (next.has(pid)) next.delete(pid)
+    else next.add(pid)
+    selected = next
+  }
+
+  function applyMark(ids: number[]): void {
+    if (!store.data || ids.length === 0) return
+    try {
+      const added = markCaught(store.data, ids, { bumpStats })
+      store.markDirty()
+      store.status = `marked ${added} caught${bumpStats ? ' (+stats)' : ''}`
+      selected = new Set()
+      tick++
+    } catch (e) {
+      store.errorDetail = e instanceof Error ? e.message : String(e)
+      store.status = 'mark failed'
+    }
+  }
+
+  function onMarkSelected(): void {
+    applyMark([...selected].filter((pid) => !caughtSet.has(pid)))
+  }
+
+  function onMarkAllUncaught(): void {
+    const ids: number[] = []
+    for (let pid = region.lo; pid <= region.hi; pid++) {
+      if (!caughtSet.has(pid)) ids.push(pid)
+    }
+    if (ids.length === 0) {
+      store.status = `all ${regionTotal} in ${region.label} already caught`
+      return
+    }
+    if (!confirm(`Mark all ${ids.length} uncaught pokémon in ${region.label} as caught?`)) {
+      return
+    }
+    applyMark(ids)
+  }
+
+  // Caught lookup for the region, independent of the uncaughtOnly view filter.
+  let caughtSet = $derived.by<Set<number>>(() => {
+    void tick
+    const s = new Set<number>()
+    if (store.data) {
+      for (const r of regionRows(store.data, region, false)) {
+        if (r.caught) s.add(r.pid)
+      }
+    }
+    return s
+  })
+</script>
+
+{#if store.data === null}
+  <p class="empty">Load a save with <strong>Browse…</strong> above to edit the Pokédex.</p>
+{:else}
+  <section class="block">
+    <p class="note">
+      Pick a region, then check rows and <strong>Mark selected</strong>, or
+      mark the whole region. Already-caught pokémon are left untouched.
+    </p>
+
+    <div class="controls">
+      <label>
+        Region:
+        <select bind:value={regionLabel}>
+          {#each REGION_RANGES as r (r.label)}
+            <option value={r.label}>{r.label}</option>
+          {/each}
+        </select>
+      </label>
+      <label class="check">
+        <input type="checkbox" bind:checked={uncaughtOnly} />
+        Show uncaught only
+      </label>
+      <span class="status">{region.label}: {caughtInRegion}/{regionTotal} caught</span>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th class="sel"></th>
+            <th>ID</th>
+            <th class="name-col">Name</th>
+            <th>caught</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each rows as row (row.pid)}
+            <tr class:caught={row.caught}>
+              <td class="sel">
+                {#if !row.caught}
+                  <input
+                    type="checkbox"
+                    checked={selected.has(row.pid)}
+                    onchange={() => toggle(row.pid)}
+                    aria-label={`Select ${row.name}`}
+                  />
+                {/if}
+              </td>
+              <td>#{row.pid}</td>
+              <td class="name-col">{row.name}</td>
+              <td>{row.caught ? '✓' : ''}</td>
+            </tr>
+          {:else}
+            <tr><td colspan="4" class="muted">(no rows)</td></tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="actions">
+      <button type="button" onclick={onMarkSelected} disabled={selected.size === 0}>
+        Mark selected caught ({selected.size})
+      </button>
+      <button type="button" onclick={onMarkAllUncaught}>
+        Mark all uncaught in {region.label}
+      </button>
+      <label class="check bump">
+        <input type="checkbox" bind:checked={bumpStats} />
+        Also bump capture stats (totalPokemonCaptured, pokemonCaptured.&lt;id&gt;, …)
+      </label>
+    </div>
+  </section>
+{/if}
+
+<style>
+  .empty {
+    color: #666;
+    padding: 1rem;
+    background: #f5f5f5;
+    border-radius: 6px;
+  }
+  .block {
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    background: #fafafa;
+  }
+  .note {
+    margin: 0 0 0.75rem;
+    color: #666;
+    font-size: 0.9em;
+  }
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.75rem;
+  }
+  .controls select {
+    font: inherit;
+    padding: 0.25rem 0.4rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-left: 0.25rem;
+  }
+  .check {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.9em;
+    color: #444;
+  }
+  .status {
+    margin-left: auto;
+    color: #444;
+    font-size: 0.9em;
+  }
+
+  .table-wrap {
+    max-height: 28rem;
+    overflow-y: auto;
+    border: 1px solid #e5e5e5;
+    border-radius: 6px;
+    background: white;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9em;
+  }
+  thead {
+    position: sticky;
+    top: 0;
+    background: #f5f5f5;
+    z-index: 1;
+  }
+  th,
+  td {
+    padding: 0.3rem 0.5rem;
+    text-align: center;
+    border-bottom: 1px solid #eee;
+  }
+  .sel {
+    width: 2rem;
+  }
+  .name-col {
+    text-align: left;
+  }
+  tbody tr.caught {
+    color: #888;
+  }
+  .muted {
+    color: #999;
+  }
+
+  .actions {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .actions button {
+    padding: 0.35rem 0.8rem;
+    border: 1px solid #ccc;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.9em;
+  }
+  .actions button:hover:not(:disabled) {
+    background: #f0f0f0;
+  }
+  .actions button:disabled {
+    color: #aaa;
+    cursor: not-allowed;
+  }
+  .bump {
+    margin-left: 0.5rem;
+  }
+</style>

--- a/web/tests/pokedex.spec.ts
+++ b/web/tests/pokedex.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure-function tests for the Pokédex mark-caught helpers — web port of
+ * pcedit_gui.PokedexTab. Marking appends minimal entries to
+ * save.party.caughtPokemon; the optional stat bump mirrors _bump_stats.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import { decodeBytes } from '../src/lib/save'
+import { REGION_RANGES, statBucketFor } from '../src/lib/data'
+import { caughtIdSet, markCaught, regionRows } from '../src/lib/pokedex'
+
+const FIXTURE = resolve(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'v0.10.25',
+  'minimal.txt',
+)
+const load = () => decodeBytes(readFileSync(FIXTURE, 'utf8').trim())
+
+// Fixture has exactly Charmander (#4) and Pikachu (#25) caught, both in Kanto.
+const KANTO = REGION_RANGES[0]
+
+function rawParty(data: ReturnType<typeof load>): Array<Record<string, unknown>> {
+  return (data.save as any).party.caughtPokemon
+}
+function stats(data: ReturnType<typeof load>): Record<string, any> {
+  return (data.save as any).statistics
+}
+
+describe('caughtIdSet', () => {
+  test('collects the ids already in the party', () => {
+    const set = caughtIdSet(load())
+    expect(set.has(4)).toBe(true)
+    expect(set.has(25)).toBe(true)
+    expect(set.size).toBe(2)
+  })
+})
+
+describe('regionRows', () => {
+  test('Kanto starts at #1 and lists the whole region', () => {
+    expect(KANTO.lo).toBe(1)
+    const rows = regionRows(load(), KANTO)
+    expect(rows.length).toBe(KANTO.hi - KANTO.lo + 1)
+    expect(rows[0]).toEqual({ pid: 1, name: 'Bulbasaur', caught: false })
+    expect(rows.find((r) => r.pid === 4)?.caught).toBe(true)
+    expect(rows.find((r) => r.pid === 25)?.caught).toBe(true)
+  })
+
+  test('uncaughtOnly drops already-caught rows', () => {
+    const rows = regionRows(load(), KANTO, true)
+    expect(rows.some((r) => r.pid === 4)).toBe(false)
+    expect(rows.some((r) => r.pid === 25)).toBe(false)
+    expect(rows.length).toBe(KANTO.hi - KANTO.lo + 1 - 2)
+  })
+})
+
+describe('markCaught', () => {
+  test('appends minimal entries for uncaught ids and skips caught ones', () => {
+    const data = load()
+    const added = markCaught(data, [1, 2, 4]) // 4 already caught
+    expect(added).toBe(2)
+    const set = caughtIdSet(data)
+    expect(set.has(1)).toBe(true)
+    expect(set.has(2)).toBe(true)
+    const entry1 = rawParty(data).find((e) => e.id === 1)
+    expect(entry1).toEqual({ '2': { '0': 0, '1': 0, '2': 0 }, '3': 1, id: 1 })
+  })
+
+  test('without bumpStats, statistics is left untouched', () => {
+    const data = load()
+    const before = JSON.stringify(stats(data))
+    markCaught(data, [1, 2, 3])
+    expect(JSON.stringify(stats(data))).toBe(before)
+  })
+
+  test('with bumpStats, capture counters and totals are updated', () => {
+    const data = load()
+    const s0 = stats(data)
+    const total0 = Number(s0.totalPokemonCaptured ?? 0)
+    const male0 = Number(s0.totalMalePokemonCaptured ?? 0)
+    // pids 1,2,3 are uncaught and (per gender-buckets.json) male-bucket.
+    markCaught(data, [1, 2, 3], { bumpStats: true })
+    const s1 = stats(data)
+    expect(Number(s1.totalPokemonCaptured)).toBe(total0 + 3)
+    expect(Number(s1.totalPokemonEncountered ?? 0)).toBeGreaterThanOrEqual(3)
+    expect(s1.pokemonCaptured['1']).toBeGreaterThanOrEqual(1)
+    expect(s1.pokemonEncountered['1']).toBeGreaterThanOrEqual(1)
+    // each of 1,2,3 maps to the male bucket in the fixture's roster
+    const maleAdded = [1, 2, 3].filter((p) => statBucketFor(p) === 'totalMalePokemonCaptured').length
+    expect(Number(s1.totalMalePokemonCaptured)).toBe(male0 + maleAdded)
+  })
+
+  test('bumpStats only counts newly-added ids, not re-marks', () => {
+    const data = load()
+    const total0 = Number(stats(data).totalPokemonCaptured ?? 0)
+    markCaught(data, [4, 25], { bumpStats: true }) // both already caught
+    expect(Number(stats(data).totalPokemonCaptured ?? 0)).toBe(total0)
+  })
+})


### PR DESCRIPTION
## Summary
Closes a parity gap — the desktop app has a Pokédex tab; the web app didn't. This ports it.

- **Pick a region** → see its dex with caught marks; **show uncaught only** filter.
- **Mark selected caught** / **Mark all uncaught in region** → append minimal entries (`{"2":{…},"3":1,id}`) to `caughtPokemon`, skipping already-caught.
- **Also bump capture stats** (off by default) → updates `statistics.pokemonCaptured/Encountered[id]`, gender buckets (via `statBucketFor`), and the `totalPokemon{Captured,Encountered}` totals.

## Implementation
- `web/src/lib/pokedex.ts` — `caughtIdSet`, `regionRows`, `markCaught` (with `bumpStats`); reuses `REGION_RANGES` / `nameFor` / `statBucketFor` from `data.ts`.
- `web/src/tabs/PokedexTab.svelte` — the UI (styled to match current tabs; themed in redesign Phase 2).
- `web/src/App.svelte` — registers the tab.

Desktop unchanged (being discontinued).

## Test Plan
- [x] `npm run test` — 116 pass (new `pokedex.spec.ts`: 7)
- [x] `npx svelte-check` — 0 errors
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)