### PR TITLE
Fix Master Ball multiplier; make Multipliers section dynamic (web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ Release notes.
   consistent with the dex.
 
 ### Fixed
+- **Multipliers: Master Ball price multiplier read a non-existent key (web).**
+  The tab read `player._itemMultipliers['Masterball|farmPoint']`, which never
+  exists (Master Balls aren't bought with farm points), so it always showed
+  1.0 even after buying Master Balls. Items like Master Ball have a *separate*
+  multiplier per currency (`Masterball|questPoint`, `|money`, `|dungeonToken`,
+  `|battlePoint`, `|diamond`). The Multipliers section is now **dynamic** —
+  it always shows the three vitamin rows (Protein/Calcium/Carbos, bought with
+  money) and additionally lists every entry actually present in the save, each
+  editable, with the 1.0-drops-the-key rule preserved. Desktop is unchanged
+  (being discontinued).
 - **Caught Pokémon: pokérus and shiny read the wrong save keys (web).**
   The Caught tab read pokérus from key `"1"` (which is actually
   `attackBonusAmount`), so the column showed large numbers instead of the

--- a/web/src/lib/currencies.ts
+++ b/web/src/lib/currencies.ts
@@ -84,31 +84,36 @@ export function writeCurrencies(data: SaveData, edits: Currencies): void {
 
 // --- multipliers ------------------------------------------------------------
 
-export type MultiplierKey =
-  | 'Protein|money'
-  | 'Calcium|money'
-  | 'Carbos|money'
-  | 'Masterball|farmPoint'
+/** A single editable price-multiplier row from `player._itemMultipliers`. */
+export type MultiplierRow = { key: string; label: string; value: number }
 
-export type MultiplierSpec = {
-  key: MultiplierKey
-  label: string
-  kind: 'vitamin' | 'ball'
-}
-
-/** Rows the tab exposes. Order matches the desktop editor for muscle memory. */
-export const MULTIPLIERS: readonly MultiplierSpec[] = [
-  { key: 'Protein|money', label: 'Protein price multiplier', kind: 'vitamin' },
-  { key: 'Calcium|money', label: 'Calcium price multiplier', kind: 'vitamin' },
-  { key: 'Carbos|money', label: 'Carbos price multiplier', kind: 'vitamin' },
-  {
-    key: 'Masterball|farmPoint',
-    label: 'Master Ball price multiplier',
-    kind: 'ball',
-  },
+/**
+ * Vitamin multipliers (bought with money) are always shown — even when absent
+ * — so they can be set on a fresh save. Everything else is surfaced
+ * dynamically from whatever the save actually contains. Items like Master Ball
+ * have a SEPARATE multiplier per currency they're buyable with
+ * (`Masterball|questPoint`, `|money`, `|dungeonToken`, …), so there is no
+ * single hardcoded key for them — listing the live entries is the only
+ * correct approach.
+ */
+export const VITAMIN_MULTIPLIER_KEYS: readonly string[] = [
+  'Protein|money',
+  'Calcium|money',
+  'Carbos|money',
 ]
 
-export type Multipliers = Record<MultiplierKey, number>
+/** "Masterball" → "Master Ball"; otherwise split PascalCase into words. */
+function prettyItem(item: string): string {
+  const special: Record<string, string> = { Masterball: 'Master Ball' }
+  return special[item] ?? item.replace(/([a-z])([A-Z])/g, '$1 $2')
+}
+
+/** Human label for an `Item|currency` multiplier key. */
+export function multiplierLabel(key: string): string {
+  const [item, currency] = key.split('|')
+  const base = `${prettyItem(item)} price multiplier`
+  return currency ? `${base} (${currency})` : base
+}
 
 function getOrCreateMultiplierBag(data: SaveData): Record<string, number> {
   const player = (data.player ?? {}) as Record<string, unknown>
@@ -121,32 +126,37 @@ function getOrCreateMultiplierBag(data: SaveData): Record<string, number> {
   return bag
 }
 
-/** Default-to-1.0 read across the canonical multiplier rows. */
-export function readMultipliers(data: SaveData): Multipliers {
+/**
+ * All multiplier rows to show: the always-shown vitamins first (at their
+ * stored value or 1.0), then every other entry actually present in
+ * `player._itemMultipliers`, sorted for a stable order.
+ */
+export function readMultipliers(data: SaveData): MultiplierRow[] {
   const player = (data.player ?? {}) as Record<string, unknown>
   const bag = (player._itemMultipliers as Record<string, number>) ?? {}
-  const out = {} as Multipliers
-  for (const { key } of MULTIPLIERS) out[key] = bag[key] ?? 1.0
-  return out
+  const rows: MultiplierRow[] = []
+  const seen = new Set<string>()
+  for (const key of VITAMIN_MULTIPLIER_KEYS) {
+    rows.push({ key, label: multiplierLabel(key), value: bag[key] ?? 1.0 })
+    seen.add(key)
+  }
+  for (const key of Object.keys(bag).sort()) {
+    if (seen.has(key)) continue
+    rows.push({ key, label: multiplierLabel(key), value: bag[key] })
+    seen.add(key)
+  }
+  return rows
 }
 
 /**
- * Mutate `data` to apply the edited multiplier values, dropping keys whose
- * value is exactly 1.0 (the game treats absent and 1.0 identically, and
- * not writing a 1.0 entry keeps fresh saves clean — matches the desktop
- * editor's behaviour since v0.5.1).
+ * Set a single multiplier. A value of exactly 1.0 deletes the key (the game
+ * treats absent and 1.0 identically; not writing 1.0 keeps fresh saves clean).
  */
-export function writeMultipliers(data: SaveData, edits: Multipliers): void {
-  const bag = getOrCreateMultiplierBag(data)
-  for (const { key } of MULTIPLIERS) {
-    const v = edits[key]
-    if (!Number.isFinite(v) || v < 0) {
-      throw new RangeError(`${key}: expected non-negative number, got ${v}`)
-    }
-    if (v === 1.0) {
-      delete bag[key]
-    } else {
-      bag[key] = v
-    }
+export function setMultiplier(data: SaveData, key: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${key}: expected non-negative number, got ${value}`)
   }
+  const bag = getOrCreateMultiplierBag(data)
+  if (value === 1.0) delete bag[key]
+  else bag[key] = value
 }

--- a/web/src/tabs/CurrenciesTab.svelte
+++ b/web/src/tabs/CurrenciesTab.svelte
@@ -9,17 +9,20 @@
 
   import { store } from '../lib/store.svelte'
   import {
-    MULTIPLIERS,
+    VITAMIN_MULTIPLIER_KEYS,
     readCurrencies,
     readMultipliers,
+    setMultiplier,
     writeCurrencies,
-    writeMultipliers,
     type Currencies,
     type CurrencyKey,
-    type MultiplierKey,
-    type Multipliers,
+    type MultiplierRow,
   } from '../lib/currencies'
   import NumberField from '../components/NumberField.svelte'
+
+  // Bump to force the multiplier list to re-read after an edit (mutations
+  // don't change store.data's identity).
+  let mtick = $state(0)
 
   // Derive the editable snapshot from store.data. Re-derives whenever the
   // user loads a new save (store.data identity changes).
@@ -30,16 +33,9 @@
     return readCurrencies(store.data)
   })
 
-  let multipliers = $derived.by<Multipliers>(() => {
-    if (!store.data) {
-      return {
-        'Protein|money': 1.0,
-        'Calcium|money': 1.0,
-        'Carbos|money': 1.0,
-        'Masterball|farmPoint': 1.0,
-      }
-    }
-    return readMultipliers(store.data)
+  let multipliers = $derived.by<MultiplierRow[]>(() => {
+    mtick // re-read after edits drop/add keys
+    return store.data ? readMultipliers(store.data) : []
   })
 
   function setCurrency(key: CurrencyKey, next: number): void {
@@ -55,30 +51,29 @@
     }
   }
 
-  function setMultiplier(key: MultiplierKey, next: number): void {
+  function commitMultiplier(key: string, next: number): void {
     if (!store.data) return
-    const edits: Multipliers = { ...multipliers, [key]: next }
     try {
-      writeMultipliers(store.data, edits)
+      setMultiplier(store.data, key, next)
       store.markDirty()
+      mtick++
     } catch (e) {
       store.errorDetail = e instanceof Error ? e.message : String(e)
       store.status = 'invalid value rejected'
     }
   }
 
-  function resetMultiplier(key: MultiplierKey): void {
-    setMultiplier(key, 1.0)
+  function resetMultiplier(key: string): void {
+    commitMultiplier(key, 1.0)
   }
 
   function resetAllVitamins(): void {
     if (!store.data) return
-    const edits: Multipliers = { ...multipliers }
-    for (const { key, kind } of MULTIPLIERS) {
-      if (kind === 'vitamin') edits[key] = 1.0
+    for (const key of VITAMIN_MULTIPLIER_KEYS) {
+      setMultiplier(store.data, key, 1.0)
     }
-    writeMultipliers(store.data, edits)
     store.markDirty()
+    mtick++
   }
 
   // Row order matches PokeClicker's `enum Currency` (and the desktop
@@ -114,12 +109,12 @@
       Higher = costs more next purchase. Reset to 1.0 to restore base price.
       A row at exactly 1.0 is dropped from the save instead of being written.
     </p>
-    {#each MULTIPLIERS as row (row.key)}
+    {#each multipliers as row (row.key)}
       <NumberField
         label={row.label}
-        value={multipliers[row.key]}
+        value={row.value}
         integer={false}
-        onCommit={(n) => setMultiplier(row.key, n)}
+        onCommit={(n) => commitMultiplier(row.key, n)}
         onReset={() => resetMultiplier(row.key)}
         resetLabel="Reset to 1.0"
       />

--- a/web/tests/currencies.spec.ts
+++ b/web/tests/currencies.spec.ts
@@ -10,11 +10,11 @@ import { describe, expect, test } from 'vitest'
 
 import { decodeBytes } from '../src/lib/save'
 import {
-  MULTIPLIERS,
+  multiplierLabel,
   readCurrencies,
   readMultipliers,
+  setMultiplier,
   writeCurrencies,
-  writeMultipliers,
 } from '../src/lib/currencies'
 
 const FIXTURE = resolve(
@@ -93,75 +93,55 @@ describe('currencies', () => {
 })
 
 describe('multipliers', () => {
-  test('readMultipliers falls back to 1.0 for missing entries', () => {
+  test('always shows the three vitamins, defaulting to 1.0', () => {
     const data = loadFixture()
-    const m = readMultipliers(data)
-    // Fixture has Protein|money = 3.5 and Masterball|farmPoint = 1.4 set;
-    // Calcium and Carbos are unset and should read as 1.0.
-    expect(m['Protein|money']).toBe(3.5)
-    expect(m['Calcium|money']).toBe(1.0)
-    expect(m['Carbos|money']).toBe(1.0)
-    expect(m['Masterball|farmPoint']).toBe(1.4)
+    const byKey = new Map(readMultipliers(data).map((r) => [r.key, r.value]))
+    expect(byKey.get('Protein|money')).toBe(3.5) // present in fixture
+    expect(byKey.get('Calcium|money')).toBe(1.0) // absent → default
+    expect(byKey.get('Carbos|money')).toBe(1.0)
   })
 
-  test('writeMultipliers drops keys at exactly 1.0', () => {
+  test('surfaces every entry actually present in the save (dynamic)', () => {
     const data = loadFixture()
-    writeMultipliers(data, {
-      'Protein|money': 1.0,
-      'Calcium|money': 1.0,
-      'Carbos|money': 1.0,
-      'Masterball|farmPoint': 1.0,
-    })
-    const bag = (data.player as any)._itemMultipliers as Record<string, number>
-    for (const { key } of MULTIPLIERS) {
-      expect(bag[key], `${key} should be absent after write of 1.0`).toBeUndefined()
-    }
+    // Fixture also has Masterball|farmPoint = 1.4 — must appear dynamically.
+    const row = readMultipliers(data).find((r) => r.key === 'Masterball|farmPoint')
+    expect(row?.value).toBe(1.4)
   })
 
-  test('writeMultipliers preserves non-1.0 values', () => {
-    const data = loadFixture()
-    writeMultipliers(data, {
-      'Protein|money': 2.0,
-      'Calcium|money': 1.0, // dropped
-      'Carbos|money': 3.5,
-      'Masterball|farmPoint': 1.7,
-    })
-    const bag = (data.player as any)._itemMultipliers as Record<string, number>
-    expect(bag['Protein|money']).toBe(2.0)
-    expect(bag['Calcium|money']).toBeUndefined()
-    expect(bag['Carbos|money']).toBe(3.5)
-    expect(bag['Masterball|farmPoint']).toBe(1.7)
-  })
-
-  test('writeMultipliers does not clobber unrelated _itemMultipliers entries', () => {
+  test('surfaces real per-currency Master Ball keys (the bug being fixed)', () => {
     const data = loadFixture()
     const bag = (data.player as any)._itemMultipliers as Record<string, number>
-    bag['Unknown|extra'] = 7.0 // simulate an unrelated entry the editor doesn't expose
-    writeMultipliers(data, {
-      'Protein|money': 1.0,
-      'Calcium|money': 1.0,
-      'Carbos|money': 1.0,
-      'Masterball|farmPoint': 1.0,
-    })
-    expect(bag['Unknown|extra']).toBe(7.0)
+    bag['Masterball|questPoint'] = 27
+    const row = readMultipliers(data).find((r) => r.key === 'Masterball|questPoint')
+    expect(row?.value).toBe(27)
   })
 
-  test('writeMultipliers rejects negative inputs', () => {
-    const data = loadFixture()
-    expect(() =>
-      writeMultipliers(data, {
-        'Protein|money': -0.5,
-        'Calcium|money': 1.0,
-        'Carbos|money': 1.0,
-        'Masterball|farmPoint': 1.0,
-      }),
-    ).toThrow(/non-negative/)
+  test('multiplierLabel formats Item|currency keys', () => {
+    expect(multiplierLabel('Masterball|questPoint')).toBe(
+      'Master Ball price multiplier (questPoint)',
+    )
+    expect(multiplierLabel('Protein|money')).toBe('Protein price multiplier (money)')
   })
 
-  test('round-trip: read → write → read returns same values', () => {
+  test('setMultiplier writes a value and drops at exactly 1.0', () => {
     const data = loadFixture()
-    const m = readMultipliers(data)
-    writeMultipliers(data, m)
-    expect(readMultipliers(data)).toEqual(m)
+    setMultiplier(data, 'Calcium|money', 2.5)
+    const bag = (data.player as any)._itemMultipliers as Record<string, number>
+    expect(bag['Calcium|money']).toBe(2.5)
+    setMultiplier(data, 'Calcium|money', 1.0)
+    expect('Calcium|money' in bag).toBe(false)
+  })
+
+  test('setMultiplier does not clobber unrelated entries', () => {
+    const data = loadFixture()
+    setMultiplier(data, 'Calcium|money', 2.0)
+    const bag = (data.player as any)._itemMultipliers as Record<string, number>
+    expect(bag['Protein|money']).toBe(3.5)
+    expect(bag['Masterball|farmPoint']).toBe(1.4)
+  })
+
+  test('setMultiplier rejects negative inputs', () => {
+    const data = loadFixture()
+    expect(() => setMultiplier(data, 'Protein|money', -0.5)).toThrow(/non-negative/)
   })
 })


### PR DESCRIPTION
## Summary
The Master Ball price multiplier always showed **1.0**, even after buying Master Balls. Root cause: the tab read `player._itemMultipliers['Masterball|farmPoint']` — a key that **never exists** (Master Balls aren't bought with farm points). Items like Master Ball have a **separate multiplier per currency** (`Masterball|questPoint`, `|money`, `|dungeonToken`, `|battlePoint`, `|diamond`), so no single hardcoded key can capture it.

## Fix — dynamic Multipliers section
- `readMultipliers` now returns `MultiplierRow[]`: always the three **vitamin** rows (Protein/Calcium/Carbos, bought with money), then **every entry actually present** in `player._itemMultipliers`, each editable. `multiplierLabel` formats `Item|currency` (e.g. "Master Ball price multiplier (questPoint)").
- `setMultiplier(data, key, value)` edits one key; the 1.0-drops-the-key rule is preserved.
- Removed the hardcoded `MULTIPLIERS` / `MultiplierKey` / `writeMultipliers`.
- `CurrenciesTab.svelte` renders the dynamic list.

Desktop has the same hardcoded mistake but is **left unchanged** (being discontinued).

## Test Plan
- [x] `npm run test` — 130 pass (multiplier tests rewritten: dynamic read, real per-currency keys surface, label formatting, set/drop)
- [x] `npx svelte-check` — 0 errors
- [x] `npm run build` — clean
- [x] Verified against a real save: Master Ball's `questPoint`/`money`/`dungeonToken`/… multipliers now appear with their true values instead of a single bogus `farmPoint` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)