### PR TITLE
Deploy web editor to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,57 @@
+name: deploy-pages
+
+# Build the web editor and publish it to GitHub Pages on every push to main
+# that touches the app or its bundled data. The production base path lives in
+# web/vite.config.ts (/pokeclicker-save-editor/), so asset URLs resolve under
+# the project site.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'data/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+# Least privilege for the OIDC-based Pages deploy.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; let an in-flight run finish rather than cancelling.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          # Relative to the repo root (actions ignore the working-directory).
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 USE AT YOUR OWN RISK. UNOFFICIAL, educational use only. 
 
 
-A small Python CLI for inspecting and editing [PokeClicker](https://www.pokeclicker.com/) save exports. Tested against `v0.10.25`.
+A save editor for [PokeClicker](https://www.pokeclicker.com/) save exports. Tested against `v0.10.25`.
+
+> **🌐 Use it in your browser — no install:** **<https://daclink.github.io/pokeclicker-save-editor/>**
+> Everything runs client-side; your save never leaves the tab. The web app is the recommended editor going forward.
+
+There's also a Python CLI and a desktop GUI (below).
 
 > **Latest release:** see <https://github.com/daclink/pokeclicker-save-editor/releases/latest>.
 > Pre-built installers are attached for macOS, Windows, and Linux — see *Download & install* below.


### PR DESCRIPTION
## Summary
Makes the web editor **live** — it had no host. Adds a GitHub Pages deploy workflow and a README link.

- `.github/workflows/deploy-pages.yml` — on push to `main` (touching `web/**` or `data/**`), builds `web/` and deploys `web/dist` to Pages via the official Pages actions (OIDC, least-privilege permissions, `concurrency: pages`).
- Pages enabled with the **GitHub Actions** source → serves at **https://daclink.github.io/pokeclicker-save-editor/** (matches the `vite.config.ts` base path).
- README: prominent "use it in your browser" link.

## After merge
The workflow runs on `main` and publishes the site (first deploy may take a couple minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)